### PR TITLE
Add Discord invite social link to docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -355,6 +355,7 @@ export default withMermaid({
         },
         socialLinks: [
           { icon: "github", link: "https://github.com/AmritaBot/AmritaCore" },
+{icon:"discord",link:"https://discord.gg/byAD3sbjjj"},
         ],
       },
     },


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Expose a Discord invite link in the documentation site's social links.