### PR TITLE
feat: allow to ignore some exception raised

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.4.1"
+version = "0.4.2"
 description = "Agent core of Project Amrita"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"


### PR DESCRIPTION
## Summary by Sourcery

Allow matchers to re-raise selected exceptions instead of swallowing them and plumb this configuration through chat handling.

New Features:
- Add support for specifying exceptions to ignore and re-raise when triggering matchers via the chat manager.

Enhancements:
- Update matcher control method docstrings to reflect refined matcher loop behavior.

Build:
- Bump project version from 0.4.1 to 0.4.2 to reflect the new behavior.