### PR TITLE
fix: return type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.4.3"
+version = "0.4.3.1"
 description = "Agent core of Project Amrita"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/amrita_core/chatmanager.py
+++ b/src/amrita_core/chatmanager.py
@@ -24,7 +24,7 @@ from .hook.event import CompletionEvent, PreCompletionEvent
 from .hook.matcher import MatcherManager
 from .libchat import call_completion, get_last_response, get_tokens, text_generator
 from .logging import debug_log, logger
-from .protocol import MessageContent, StringMessageContent
+from .protocol import MessageContent
 from .sessions import SessionsManager
 from .tokenizer import hybrid_token_count
 from .types import (
@@ -790,11 +790,9 @@ class ChatObject:
         async for chunk in call_completion(
             send_messages, config=self.config, preset=self.preset
         ):
-            if isinstance(chunk, str):
-                await self.yield_response(StringMessageContent(chunk))
-            elif isinstance(chunk, UniResponse):
+            if isinstance(chunk, UniResponse):
                 response = chunk
-            elif isinstance(chunk, MessageContent):
+            elif isinstance(chunk, MessageContent | str):
                 await self.yield_response(chunk)
         if response is None:
             raise RuntimeError("No final response from chat adapter.")

--- a/uv.lock
+++ b/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "amrita-core"
-version = "0.4.2.1"
+version = "0.4.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary by Sourcery

Adjust chat response streaming to treat both MessageContent and raw string chunks as streamable output while preserving UniResponse as the final result, and bump the package patch version.

Bug Fixes:
- Ensure string chunks returned from chat completion are correctly handled as streamed message content rather than being ignored.

Build:
- Bump project version from 0.4.3 to 0.4.3.1.