### PR TITLE
Introduce template-based ReAct agents and Hybrid MoE strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,8 @@ vite.config.ts.timestamp-*
 
 # Pytest
 test-results.xml
+
+# Other
+
+/patch.diff
+.env.*

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -443,7 +443,6 @@ export default withMermaid({
                 text: "MCP 服务器集成",
                 link: "/zh/guide/extensions-integration/mcp-server-integration",
               },
-              ,
             ],
           },
           {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -183,8 +183,16 @@ export default withMermaid({
                 link: "/guide/api-reference/classes/BaseModel",
               },
               {
+                text: "BaseReActAgentStrategy",
+                link: "/guide/api-reference/classes/BaseReActAgentStrategy",
+              },
+              {
                 text: "ChatObject",
                 link: "/guide/api-reference/classes/ChatObject",
+              },
+              {
+                text: "ClientManager",
+                link: "/guide/api-reference/classes/ClientManager",
               },
               {
                 text: "Depends",
@@ -195,6 +203,10 @@ export default withMermaid({
                 link: "/guide/api-reference/classes/DependsFactory",
               },
               {
+                text: "FallbackContext",
+                link: "/guide/api-reference/classes/FallbackContext",
+              },
+              {
                 text: "Function",
                 link: "/guide/api-reference/classes/Function",
               },
@@ -203,8 +215,8 @@ export default withMermaid({
                 link: "/guide/api-reference/classes/FunctionDefinitionSchema",
               },
               {
-                text: "FallbackContext",
-                link: "/guide/api-reference/classes/FallbackContext",
+                text: "HybridReActAgentStrategy",
+                link: "/guide/api-reference/classes/HybridReActAgentStrategy",
               },
               {
                 text: "MemoryModel",
@@ -223,20 +235,24 @@ export default withMermaid({
                 link: "/guide/api-reference/classes/ModelPreset",
               },
               {
-                text: "PresetManager",
-                link: "/guide/api-reference/classes/PresetManager",
+                text: "MCPClient",
+                link: "/guide/api-reference/classes/MCPClient",
               },
               {
                 text: "MultiClientManager",
                 link: "/guide/api-reference/classes/MultiClientManager",
               },
               {
-                text: "MCPClient",
-                link: "/guide/api-reference/classes/MCPClient",
+                text: "NoActionAgentStrategy",
+                link: "/guide/api-reference/classes/NoActionAgentStrategy",
               },
               {
-                text: "ClientManager",
-                link: "/guide/api-reference/classes/ClientManager",
+                text: "PresetManager",
+                link: "/guide/api-reference/classes/PresetManager",
+              },
+              {
+                text: "ReActAgentStrategy",
+                link: "/guide/api-reference/classes/ReActAgentStrategy",
               },
               {
                 text: "StrategyContext",
@@ -423,6 +439,11 @@ export default withMermaid({
                 text: "Jinja2 模板",
                 link: "/zh/guide/extensions-integration/jinja2-templates",
               },
+              {
+                text: "MCP 服务器集成",
+                link: "/zh/guide/extensions-integration/mcp-server-integration",
+              },
+              ,
             ],
           },
           {
@@ -458,8 +479,16 @@ export default withMermaid({
                 link: "/zh/guide/api-reference/classes/BaseModel",
               },
               {
+                text: "BaseReActAgentStrategy",
+                link: "/zh/guide/api-reference/classes/BaseReActAgentStrategy",
+              },
+              {
                 text: "ChatObject",
                 link: "/zh/guide/api-reference/classes/ChatObject",
+              },
+              {
+                text: "ClientManager",
+                link: "/zh/guide/api-reference/classes/ClientManager",
               },
               {
                 text: "Depends",
@@ -482,6 +511,10 @@ export default withMermaid({
                 link: "/zh/guide/api-reference/classes/FunctionDefinitionSchema",
               },
               {
+                text: "HybridReActAgentStrategy",
+                link: "/zh/guide/api-reference/classes/HybridReActAgentStrategy",
+              },
+              {
                 text: "MemoryModel",
                 link: "/zh/guide/api-reference/classes/MemoryModel",
               },
@@ -498,20 +531,24 @@ export default withMermaid({
                 link: "/zh/guide/api-reference/classes/ModelPreset",
               },
               {
-                text: "PresetManager",
-                link: "/zh/guide/api-reference/classes/PresetManager",
+                text: "MCPClient",
+                link: "/zh/guide/api-reference/classes/MCPClient",
               },
               {
                 text: "MultiClientManager",
                 link: "/zh/guide/api-reference/classes/MultiClientManager",
               },
               {
-                text: "MCPClient",
-                link: "/zh/guide/api-reference/classes/MCPClient",
+                text: "NoActionAgentStrategy",
+                link: "/zh/guide/api-reference/classes/NoActionAgentStrategy",
               },
               {
-                text: "ClientManager",
-                link: "/zh/guide/api-reference/classes/ClientManager",
+                text: "PresetManager",
+                link: "/zh/guide/api-reference/classes/PresetManager",
+              },
+              {
+                text: "ReActAgentStrategy",
+                link: "/zh/guide/api-reference/classes/ReActAgentStrategy",
               },
               {
                 text: "StrategyContext",

--- a/docs/guide/api-reference/classes/AgentStrategy.md
+++ b/docs/guide/api-reference/classes/AgentStrategy.md
@@ -79,3 +79,25 @@ Handle exceptions that occur during strategy execution.
 **Parameters**:
 
 - `exc` (BaseException): The exception that occurred during execution
+
+### on_post_process()
+
+Post-execution hook that is called after all agent steps complete successfully.
+
+This method is invoked for **all strategy categories** (`"agent"`, `"rag"`, `"workflow"`, `"agent-mixed"`), and only when execution completes without exceptions.
+
+**Returns**: None
+
+**Usage**: This hook can be used to perform final context modifications, add completion instructions, or perform cleanup operations before the final response is generated.
+
+```python
+async def on_post_process(self) -> None:
+    """Called after successful agent execution"""
+    if self.call_count >= 2:  # Only if tools were actually called
+        self.ctx.message.append(
+            Message(
+                role="user",
+                content="<END_OF_PROCESS>\nPlease answer me directly by the informations we got before.\n<END_OF_PROCESS>"
+            )
+        )
+```

--- a/docs/guide/api-reference/classes/AgentStrategy.md
+++ b/docs/guide/api-reference/classes/AgentStrategy.md
@@ -97,7 +97,7 @@ async def on_post_process(self) -> None:
         self.ctx.message.append(
             Message(
                 role="user",
-                content="<END_OF_PROCESS>\nPlease answer me directly by the informations we got before.\n<END_OF_PROCESS>"
+                content="<END_OF_PROCESS>\nPlease answer me directly based on the information we got before.\n<END_OF_PROCESS>"
             )
         )
 ```

--- a/docs/guide/api-reference/classes/BaseReActAgentStrategy.md
+++ b/docs/guide/api-reference/classes/BaseReActAgentStrategy.md
@@ -1,0 +1,134 @@
+# BaseReActAgentStrategy
+
+`BaseReActAgentStrategy` is an abstract base class for ReAct agent strategies that implements the template method pattern for unified execution flow.
+
+This class provides shared functionality for ReAct-style agents including tool calling orchestration, reasoning message generation, loop detection, and common error handling patterns.
+
+## Inheritance
+
+- Extends: [AgentStrategy](AgentStrategy.md)
+- Abstract Base Class: Yes
+
+## Properties
+
+- `agent_last_step` (str | None): Tracks the last reasoning step or action taken
+- `call_count` (int): Counter for tool call iterations
+- `tools` (list[Any]): List of available tools for the agent
+- `origin_msg` (str): Original user message content
+- `origin_instruction` (str): System instruction from training context
+- `reasoning_pc` (int): Reasoning process counter for loop detection
+- `_suggested_stop` (bool): Flag indicating whether to switch tool_choice to auto mode
+
+## Constructor Parameters
+
+- `ctx` ([StrategyContext](StrategyContext.md)): Strategy context containing chat_object, configuration, and message context
+
+## Template Method Pattern
+
+`BaseReActAgentStrategy` implements the template method pattern where the common execution flow is defined in `_execute_tool_loop()`, but strategy-specific behaviors are delegated to abstract methods:
+
+### Abstract Methods (Must be implemented by subclasses)
+
+#### \_append_tool_result_to_context()
+
+Append tool result to context (strategy-specific).
+
+**Parameters**:
+
+- `tool_call` ([ToolCall](ToolCall.md)): The tool call object
+- `func_response` (str): The function execution result
+- `response_msg` ([UniResponse](UniResponse.md)): The original response message
+
+#### \_handle_error_append()
+
+Handle appending error messages to context (strategy-specific).
+
+**Parameters**:
+
+- `function_name` (str): Name of the failed function
+- `error_content` (str): Formatted error message to append
+- `tool_call_id` (str): ID of the tool call
+- `original_exception` (BaseException): The original exception object for type-based handling
+
+#### \_append_reasoning()
+
+Append reasoning content to context (strategy-specific).
+
+**Parameters**:
+
+- `response` ([UniResponse](UniResponse.md)): The response from tools_caller containing reasoning tool calls
+
+### Concrete Methods (Can be overridden by subclasses)
+
+#### \_build_stop_response()
+
+Build the stop tool response message.
+
+**Parameters**:
+
+- `function_args` (dict[str, Any]): Arguments passed to the stop tool
+
+**Returns**: str - The instruction message for final answer generation
+
+#### \_check_and_handle_loop_reasoning()
+
+Check if loop reasoning threshold has been exceeded and build prompt.
+
+**Returns**: str | None - Loop detection prompt if threshold exceeded, None otherwise
+
+#### \_notify_tool_calls()
+
+Send tool call completion notifications to user.
+
+**Parameters**:
+
+- `result_msg_list` (list[[ToolResult](ToolResult.md)]): List of tool results to notify
+- `function_name` (str): Name of the called function
+- `tool_call_id` (str): ID of the tool call
+
+#### \_handle_loop_reasoning_cleanup()
+
+Clean up strategy-specific state when loop reasoning is detected.
+
+**Parameters**:
+
+- `prompt` (str): The loop detection prompt message
+
+#### \_build_stop_response_and_append()
+
+Build stop response and append to message list (strategy-specific).
+
+**Parameters**:
+
+- `function_args` (dict[str, Any]): Arguments passed to the stop tool
+- `response_msg` ([UniResponse](UniResponse.md)): The original response message
+
+## Usage
+
+This class should not be instantiated directly. Instead, create subclasses that implement the required abstract methods:
+
+```python
+from amrita_core.builtins.agent import BaseReActAgentStrategy
+
+class MyCustomReActStrategy(BaseReActAgentStrategy):
+    async def _append_tool_result_to_context(self, tool_call, func_response, response_msg):
+        # Implement strategy-specific tool result handling
+        pass
+
+    async def _handle_error_append(self, function_name, error_content, tool_call_id, original_exception):
+        # Implement strategy-specific error handling
+        pass
+
+    async def _append_reasoning(self, response):
+        # Implement strategy-specific reasoning handling
+        pass
+
+    @classmethod
+    def get_category(cls):
+        return "agent-mixed"
+```
+
+## Built-in Subclasses
+
+- [ReActAgentStrategy](ReActAgentStrategy.md): Standard implementation with OpenAI-compatible ToolCall-ToolResult pairing
+- [HybridReActAgentStrategy](HybridReActAgentStrategy.md): Specialized implementation for MoE architecture models using XML tags

--- a/docs/guide/api-reference/classes/HybridReActAgentStrategy.md
+++ b/docs/guide/api-reference/classes/HybridReActAgentStrategy.md
@@ -1,0 +1,92 @@
+# HybridReActAgentStrategy
+
+`HybridReActAgentStrategy` is a specialized agent strategy **optimized for Mixture of Experts (MoE) architecture models**.
+
+This strategy addresses the ambiguity in internal state machines of certain MoE models when distinguishing between Tool and Completion identifiers. Unlike traditional toolchain approaches that rely on explicit ToolCall-ToolResult interactions, this hybrid approach uses ToolCall triggering combined with appending pure text directly to the context.
+
+## Inheritance
+
+- Extends: [BaseReActAgentStrategy](BaseReActAgentStrategy.md)
+- Category: `"agent-mixed"`
+
+## Key Characteristics
+
+- **ToolCall Triggering**: Initiates tool execution through standard ToolCall mechanisms
+- **Context-Based Integration**: Appends tool results as plain text messages rather than structured ToolResult objects
+- **XML Tag Format**: Uses `<TOOL_CALL>` and `<TOOL_RESULT>` XML tags to represent tool interactions
+- **MoE-Specific Optimization**: Resolves issues where MoE models struggle to differentiate between tool invocation states and completion states
+
+## Properties
+
+- `regexes` (ClassVar[list[tuple[re.Pattern, str]]]): Regular expressions for XML tag sanitization
+- `_tool_call_jinja2` ([Template](https://jinja.palletsprojects.com/)): Jinja2 template for rendering tool calls and results
+- `_process_message` (list[str]): Temporary storage for processed tool messages
+
+## Constructor Parameters
+
+- `ctx` ([StrategyContext](StrategyContext.md)): Strategy context containing chat_object, configuration, and message context
+
+## Tool Function Schema
+
+```xml
+<!-- Tool Call -->
+<TOOL_CALL name="tool">
+    <PARAMS>
+        <!-- Parameters are passed as key-value pairs -->
+        <PARAM name="param1">value1</PARAM>
+    </PARAMS>
+</TOOL_CALL>
+
+<!-- Tool Result -->
+<TOOL_RESULT name="tool">
+   Tool execution result content
+</TOOL_RESULT>
+```
+
+## Security Considerations
+
+**⚠️ Important Security Warning**:
+
+- **Prompt Injection Risk**: Appending tool results as plain `user` messages may expose the model to injection attacks if tool outputs are untrusted or unsanitized
+- **Minimal Sanitization**: This strategy only provides basic tag pair escaping and does **NOT** perform semantic-level filtering or content validation
+- **Security Responsibility**: Users **MUST** implement comprehensive input validation, semantic analysis, and content sanitization for tool results in production environments
+
+## Usage Example
+
+```python
+import asyncio
+from amrita_core import create_agent, minimal_init
+from amrita_core.builtins.agent import HybridReActAgentStrategy
+
+async def use_hybrid_strategy():
+    # Initialize AmritaCore
+    await minimal_init()
+
+    # Create agent with hybrid strategy for MoE models
+    agent = create_agent(
+        url="https://api.moemodel.com",
+        key="your-api-key",
+        strategy=HybridReActAgentStrategy
+    )
+
+    # Use the agent
+    chat = agent.get_chatobject("Analyze this data using available tools")
+    async with chat.begin():
+        response = await chat.full_response()
+```
+
+## When to Use
+
+Use `HybridReActAgentStrategy` when working with:
+
+- **Mixture of Experts (MoE) models** like Mixtral, Qwen-MoE, etc.
+- Models that exhibit inconsistent behavior with standard ToolCall-ToolResult message pairs
+- Scenarios where the model's internal state machine has difficulty distinguishing between tool invocation and completion states
+
+## When NOT to Use
+
+Avoid `HybridReActAgentStrategy` when:
+
+- Working with standard LLM providers (OpenAI, Anthropic, etc.) - use [ReActAgentStrategy](ReActAgentStrategy.md) instead
+- Security is a primary concern and you cannot implement proper input validation
+- You need strict OpenAI-compatible message formatting

--- a/docs/guide/api-reference/classes/NoActionAgentStrategy.md
+++ b/docs/guide/api-reference/classes/NoActionAgentStrategy.md
@@ -1,0 +1,63 @@
+# NoActionAgentStrategy
+
+`NoActionAgentStrategy` is a simple workflow strategy that performs no action. It can be used to give up the tool calling process when needed.
+
+## Inheritance
+
+- Extends: [AgentStrategy](AgentStrategy.md)
+- Category: `"workflow"`
+
+## Constructor Parameters
+
+- `ctx` ([StrategyContext](StrategyContext.md)): Strategy context containing chat_object, configuration, and message context
+
+## Methods
+
+### run()
+
+No-action implementation that returns immediately without performing any operations.
+
+**Returns**: None
+
+### on_exception()
+
+No-action exception handler that returns immediately without performing any operations.
+
+**Parameters**:
+
+- `exc` (BaseException): The exception that occurred
+
+**Returns**: None
+
+## Usage Example
+
+```python
+import asyncio
+from amrita_core import create_agent, minimal_init
+from amrita_core.builtins.agent import NoActionAgentStrategy
+
+async def use_no_action_strategy():
+    # Initialize AmritaCore
+    await minimal_init()
+
+    # Create agent with no-action strategy to skip tool execution
+    agent = create_agent(
+        url="https://api.example.com",
+        key="your-api-key",
+        strategy=NoActionAgentStrategy
+    )
+
+    # Use the agent - it will respond directly without calling tools
+    chat = agent.get_chatobject("Just respond to this query directly")
+    async with chat.begin():
+        response = await chat.full_response()
+```
+
+## When to Use
+
+Use `NoActionAgentStrategy` when:
+
+- You want to skip tool execution entirely
+- You need a simple direct response without any tool calling logic
+- You're implementing conditional logic where tool calling should be bypassed in certain scenarios
+- You need a placeholder strategy for testing or debugging purposes

--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -66,6 +66,7 @@ AmritaCore provides built-in adapters for multiple LLM providers, implementing t
 - **API Calls**: Asynchronous calls to the Anthropic API
 - **Streaming Responses**: Supports streaming with message stream handling
 - **Token Tracking**: Proper input/output token tracking for Anthropic's usage model
+- **Message Filtering**: Automatically filters out invalid messages (assistant messages with `content=None` and all tool messages) to comply with Anthropic API requirements
 
 **Supported Protocols**: `"anthropic"`, `"claude"`
 
@@ -73,16 +74,30 @@ AmritaCore provides built-in adapters for multiple LLM providers, implementing t
 
 ## 9.3 Built-in Agent System
 
-AmritaCore includes a comprehensive intelligent agent system capable of autonomously using tools to complete tasks.
+AmritaCore includes a comprehensive intelligent agent system capable of autonomously using tools to complete tasks. The system has been significantly enhanced with a **template method pattern** architecture that provides unified execution flow while allowing strategy-specific customization.
 
-### 9.3.1 ReActAgentStrategy
+### 9.3.1 BaseReActAgentStrategy (Abstract Base Class)
 
-The `ReActAgentStrategy` is the built-in agent strategy that implements the `"agent-mixed"` category, supporting both retrieval-augmented generation (RAG) and iterative tool calling within the same execution framework.
+`BaseReActAgentStrategy` is the abstract base class that implements the template method pattern for ReAct-style agents. It provides shared functionality including:
+
+- **Tool calling orchestration** and execution flow control
+- **Reasoning message generation** and processing
+- **Loop detection and recovery mechanisms** (detects excessive duplicate reasoning calls)
+- **Tool call notification handling** with configurable user notifications
+- **Common error handling patterns** with proper exception management
+- **Unified stop state management** via the `_suggested_stop` flag
+
+This abstract class defines the common execution framework that all ReAct-style strategies inherit from, ensuring consistent behavior while allowing customization through abstract methods.
+
+### 9.3.2 ReActAgentStrategy
+
+The `ReActAgentStrategy` is the standard implementation that inherits from `BaseReActAgentStrategy` and implements the `"agent-mixed"` category, supporting both retrieval-augmented generation (RAG) and iterative tool calling within the same execution framework.
 
 **Key Features**:
 
 - **Dynamic Mode Switching**: Automatically adapts between RAG and agent modes based on configuration
 - **Built-in Tool Integration**: Seamlessly integrates with all built-in tools (`STOP_TOOL`, `REASONING_TOOL`, `PROCESS_MESSAGE`)
+- **Standard ToolCall-ToolResult Pairing**: Maintains strict adherence to OpenAI-compatible message formats
 - **Reasoning Support**: Optional reasoning step generation before tool execution
 - **Error Handling**: Comprehensive error handling with user notifications
 - **Session Management**: Full session state management with memory retention
@@ -95,124 +110,89 @@ The `ReActAgentStrategy` is the built-in agent strategy that implements the `"ag
 - **Intermediate Messages**: Controls visibility of processing messages and reasoning steps
 - **Error Notifications**: Configurable error reporting to users
 
-### 9.3.2 Agent Workflow
+### 9.3.3 HybridReActAgentStrategy
 
-The built-in agent system follows this enhanced workflow:
+`HybridReActAgentStrategy` is a specialized agent strategy **optimized for Mixture of Experts (MoE) architecture models**. It addresses the ambiguity in internal state machines of certain MoE models when distinguishing between Tool and Completion identifiers.
 
-1. **Initialization**: Create agent with `create_agent()` or `AgentRuntime`
-2. **Context Setup**: Initialize conversation context with system prompt and memory
-3. **Mode Detection**: Determine execution mode (RAG vs Agent) based on configuration
-4. **Reasoning Phase** (Optional): Generate reasoning step if thought mode is enabled
-5. **Tool Selection**: Select appropriate tools based on current situation and available tools
-6. **Tool Execution**: Execute selected tools with proper error handling
-7. **Result Processing**: Process tool results and update conversation context
-8. **Iteration Control**: Manage iteration limits and termination conditions
-9. **Completion**: Use `STOP_TOOL` to end the task or provide final response
+**Key Characteristics**:
 
-### 9.3.3 Core API Functions
+- **ToolCall Triggering**: Initiates tool execution through standard ToolCall mechanisms
+- **Context-Based Integration**: Appends tool results as plain text messages rather than structured ToolResult objects, avoiding MoE model state ambiguity
+- **XML Tag Format**: Uses `<TOOL_CALL>` and `<TOOL_RESULT>` XML tags to represent tool interactions
+- **MoE-Specific Optimization**: Resolves issues where MoE models struggle to differentiate between tool invocation states and completion states
 
-AmritaCore provides high-level factory functions for simplified agent creation:
+**Tool Function Schema**:
 
-#### create_agent()
+```xml
+<!-- Tool Call -->
+<TOOL_CALL name="tool">
+    <PARAMS>
+        <!-- Parameters are passed as key-value pairs -->
+        <PARAM name="param1">value1</PARAM>
+    </PARAMS>
+</TOOL_CALL>
 
-A factory function that creates an `AgentRuntime` instance with minimal parameters:
-
-```python
-from amrita_core import create_agent, minimal_init
-
-async def example():
-    await minimal_init()
-    agent = create_agent(
-        base_url="https://api.example.com",
-        api_key="your-api-key",
-        model="gpt-4",
-        model_config={"temperature": 0.7}
-    )
-    chat = agent.get_chatobject("What can you do?")
-    async with chat.begin():
-        response = await chat.full_response()
-    return response
+<!-- Tool Result -->
+<TOOL_RESULT name="tool">
+   Tool execution result content
+</TOOL_RESULT>
 ```
 
-**Parameters**:
+**Known Limitations and Security Considerations**:
 
-- `base_url`: API endpoint URL
-- `api_key`: Authentication API key
-- `model`: Model name (defaults to "auto")
-- `train`: Custom system prompt (optional)
-- `model_config`: Model configuration parameters
-- `config`: Amrita configuration object (optional)
+- **Prompt Injection Risk**: Appending tool results as plain `user` messages may expose the model to injection attacks if tool outputs are untrusted or unsanitized
+- **Minimal Sanitization**: This strategy only provides basic tag pair escaping and does **NOT** perform semantic-level filtering or content validation
+- **Security Responsibility**: Users **MUST** implement comprehensive input validation, semantic analysis, and content sanitization for tool results in production environments
 
-#### AgentRuntime
+### 9.3.4 NoActionAgentStrategy
 
-The underlying runtime class that provides full control over agent configuration:
+`NoActionAgentStrategy` is a simple workflow strategy that performs no action. It can be used to give up the tool calling process when needed.
 
-```python
-from amrita_core import AgentRuntime, minimal_init
-from amrita_core.config import get_config
-from amrita_core.types import ModelPreset, ModelConfig
+- **Category**: `"workflow"`
+- **Use Case**: When you need to skip tool execution entirely
+- **Implementation**: Empty `run()` method that returns immediately
 
-async def advanced_example():
-    await minimal_init()
-    config = get_config()
-    preset = ModelPreset(
-        name="custom_preset",
-        base_url="https://api.example.com",
-        api_key="your-api-key",
-        model="gpt-4",
-        config=ModelConfig(temperature=0.7, stream=True)
-    )
+### 9.3.5 Agent Workflow and Template Method Pattern
 
-    agent = AgentRuntime(
-        config=config,
-        preset=preset,
-        train={"content": "You are a helpful assistant.", "role": "system"}
-    )
+The built-in agent system follows an enhanced workflow using the template method pattern:
 
-    chat = agent.get_chatobject("Hello!")
-    async with chat.begin():
-        async for chunk in chat.get_response_generator():
-            print(chunk, end="")
-```
+1. **Initialization**: Strategy context is created with user input and conversation history
+2. **Tool Preparation**: Available tools are determined based on configuration
+3. **Reasoning Phase** (optional): If configured, reasoning step is generated
+4. **Tool Execution Loop**:
+   - Tools are called based on model decisions
+   - Results are processed according to strategy-specific logic
+   - Loop detection prevents infinite reasoning cycles
+5. **Post-Processing**: The `on_post_process()` hook is called for final context modifications
+6. **Completion**: Final response is generated
 
-## 9.4 Built-in Security Features
+The template method pattern ensures that steps 1-4 and 6 follow a consistent flow across all strategies, while step 5 (result processing) and error handling are customized per strategy implementation.
 
-### 9.4.1 Cookie Security Detection
+### 9.3.6 Strategy Selection Guidelines
 
-AmritaCore includes built-in cookie security detection to prevent prompt injection attacks:
+Choose the appropriate built-in strategy based on your use case:
 
-- **Automatic Cookie Generation**: Unique cookies are automatically generated for each session
-- **Leakage Detection**: Monitors responses for cookie presence indicating potential injection
-- **Automatic Response Blocking**: Blocks responses containing cookies and returns error messages
+- **Standard LLM Providers** (OpenAI, Anthropic, etc.): Use `ReActAgentStrategy`
+- **MoE Architecture Models** (Mixtral, Qwen-MoE, etc.): Use `HybridReActAgentStrategy`
+- **Skip Tool Execution**: Use `NoActionAgentStrategy`
+- **Custom Behavior**: Extend `BaseReActAgentStrategy` or implement your own `AgentStrategy`
 
-### 9.4.2 Session Isolation
+## 9.4 Built-in Event Hooks
 
-Built-in session management ensures complete isolation between different users or conversations:
+AmritaCore provides built-in event hooks for common scenarios:
 
-- **SessionsManager**: Singleton class managing session lifecycle
-- **SessionData**: Per-session configuration, tools, and memory
-- **Automatic Cleanup**: Sessions are automatically cleaned up when no longer needed
+### 9.4.1 Cookie Security Hook
 
-## 9.5 Built-in Event System
+The cookie security hook automatically detects if sensitive cookie values appear in model responses and terminates the session to prevent data leakage.
 
-AmritaCore provides a comprehensive event-driven architecture with built-in event handlers:
+- **Activation**: Enabled when `config.cookie.enable_cookie = True`
+- **Detection**: Scans model responses for configured cookie values
+- **Response**: Terminates session and returns generic error message on detection
 
-### 9.5.1 PreCompletionEvent
+### 9.4.2 Post-Process Hook
 
-Triggered before sending requests to LLM, allowing message modification and preset switching.
+The `on_post_process()` hook is called after successful strategy execution and can be used for final context modifications or cleanup operations.
 
-### 9.5.2 CompletionEvent
-
-Triggered after receiving responses from LLM, enabling response processing and security checks.
-
-### 9.5.3 FallbackContext
-
-Handles LLM request failures with automatic retry logic and preset fallback mechanisms.
-
-### 9.5.4 Built-in Event Handlers
-
-- **Cookie Security Handler**: Automatically checks for cookie leaks in responses
-- **Tool Call Notifications**: Provides real-time feedback on tool execution status
-- **Error Propagation**: Ensures proper error handling across the execution pipeline
-
-These built-in capabilities provide a solid foundation for developing sophisticated AI agents while maintaining security, performance, and extensibility.
+- **Timing**: Called after all tool executions complete successfully
+- **Applicability**: Available for **all strategy categories** (`"agent"`, `"rag"`, `"workflow"`, `"agent-mixed"`)
+- **Use Cases**: Adding final instructions, context summarization, or cleanup operations

--- a/docs/guide/concepts/agent-strategy.md
+++ b/docs/guide/concepts/agent-strategy.md
@@ -36,6 +36,21 @@ AmritaCore supports four distinct strategy categories, each designed for specifi
 - **Use Case**: Agents that need to adapt between RAG and iterative tool calling based on context
 - **Context**: Full conversation history with dynamic behavior adaptation
 
+### Template Method Pattern Architecture
+
+AmritaCore's agent strategy system has been enhanced with a **template method pattern** that provides a unified execution framework while allowing strategy-specific customization.
+
+The `BaseReActAgentStrategy` abstract base class defines the common execution flow:
+
+1. **Tool Call Generation**: Model generates tool calls based on current context
+2. **Tool Execution Loop**: Each tool call is processed through a standardized flow
+3. **Result Processing**: Strategy-specific logic handles how results are added to context
+4. **Loop Detection**: Automatic detection and handling of reasoning loops
+5. **Error Handling**: Common error patterns with strategy-specific recovery
+6. **Post-Processing**: Optional `on_post_process()` hook for final modifications
+
+This pattern ensures consistent behavior across all ReAct-style strategies while allowing customization through abstract methods like `_append_tool_result_to_context()` and `_handle_error_append()`.
+
 ### Unified Tool Interface
 
 All agent strategies inherit the `call_tool()` method from the base `AgentStrategy` class. This provides a **unified interface for tool execution** that ensures consistency across all strategy implementations in AmritaCore.
@@ -49,11 +64,57 @@ Key characteristics of the unified tool interface:
 
 This unified interface guarantees that regardless of which strategy category you implement, tool calling behavior remains consistent and predictable throughout the AmritaCore ecosystem.
 
+### Built-in Strategy Implementations
+
+#### ReActAgentStrategy
+
+The standard implementation that follows OpenAI-compatible ToolCall-ToolResult pairing. It maintains strict message format compliance and is suitable for most LLM providers.
+
+#### HybridReActAgentStrategy
+
+A specialized implementation optimized for **Mixture of Experts (MoE) architecture models**. Instead of standard ToolCall-ToolResult pairs, it uses XML tags (`<TOOL_CALL>`, `<TOOL_RESULT>`) embedded directly in the conversation context as plain text messages.
+
+This approach resolves state machine ambiguity issues in MoE models but requires careful security consideration due to potential prompt injection risks.
+
+#### NoActionAgentStrategy
+
+A minimal workflow strategy that performs no action, useful for skipping tool execution when needed.
+
 ## Implementation Guide
 
 ### Creating Custom Agent Strategies
 
-To create a custom agent strategy, extend the `AgentStrategy` abstract base class and implement the required methods:
+To create a custom agent strategy, you have two options:
+
+#### Option 1: Extend BaseReActAgentStrategy (Recommended for ReAct-style agents)
+
+```python
+from amrita_core.builtins.agent import BaseReActAgentStrategy
+from typing import Literal
+
+class MyCustomReActStrategy(BaseReActAgentStrategy):
+    def __init__(self, ctx):
+        super().__init__(ctx)
+        # Initialize custom state
+
+    async def _append_tool_result_to_context(self, tool_call, func_response, response_msg):
+        # Implement how tool results are added to context
+        pass
+
+    async def _handle_error_append(self, function_name, error_content, tool_call_id, original_exception):
+        # Implement error handling specific to your strategy
+        pass
+
+    async def _append_reasoning(self, response):
+        # Implement reasoning step handling
+        pass
+
+    @classmethod
+    def get_category(cls) -> Literal["agent-mixed"]:
+        return "agent-mixed"
+```
+
+#### Option 2: Extend AgentStrategy directly (For completely custom behavior)
 
 ```python
 from amrita_core.agent.strategy import AgentStrategy
@@ -69,6 +130,11 @@ class MyCustomAgentStrategy(AgentStrategy):
         # Return True to continue, False to stop
         return True
 
+    async def on_post_process(self) -> None:
+        # Optional: Implement post-processing logic
+        # Called after successful execution in agent/agent-mixed modes
+        pass
+
     @classmethod
     def get_category(cls) -> Literal["agent"]:
         return "agent"
@@ -76,73 +142,69 @@ class MyCustomAgentStrategy(AgentStrategy):
 
 ### Using Built-in Strategies
 
-AmritaCore provides the `ReActAgentStrategy` as a built-in implementation that supports the `"agent-mixed"` category:
+AmritaCore provides multiple built-in strategies for different use cases:
 
 ```python
 import asyncio
 from amrita_core import create_agent, minimal_init
-from amrita_core.builtins.agent import ReActAgentStrategy
+from amrita_core.builtins.agent import (
+    ReActAgentStrategy,
+    HybridReActAgentStrategy,
+    NoActionAgentStrategy
+)
 
-async def use_builtin_strategy():
+async def use_builtin_strategies():
     # Initialize AmritaCore
     await minimal_init()
 
-    # Create agent with custom strategy
-    agent = create_agent(
-        url="https://api.example.com",
+    # Standard ReAct strategy (recommended for most cases)
+    standard_agent = create_agent(
+        url="https://api.openai.com",
         key="your-api-key",
         strategy=ReActAgentStrategy
     )
 
-    # Use the agent
-    chat = agent.get_chatobject("What can you do?")
-    async with chat.begin():
-        response = await chat.full_response()
+    # Hybrid strategy for MoE models
+    hybrid_agent = create_agent(
+        url="https://api.moemodel.com",
+        key="your-api-key",
+        strategy=HybridReActAgentStrategy
+    )
 
-    return response
+    # No-action strategy to skip tool execution
+    no_action_agent = create_agent(
+        url="https://api.example.com",
+        key="your-api-key",
+        strategy=NoActionAgentStrategy
+    )
 
-# Run the example
-if __name__ == "__main__":
-    asyncio.run(use_builtin_strategy())
+    # Use the agents
+    chat1 = standard_agent.get_chatobject("What can you do?")
+    chat2 = hybrid_agent.get_chatobject("Analyze this data")
+    chat3 = no_action_agent.get_chatobject("Just respond directly")
+
+    async with chat1.begin(), chat2.begin(), chat3.begin():
+        response1 = await chat1.full_response()
+        response2 = await chat2.full_response()
+        response3 = await chat3.full_response()
 ```
 
-## Strategy Context
+### Post-Process Hook
 
-The `StrategyContext` provides all necessary information for strategy execution:
+The `on_post_process()` method is a new lifecycle hook that is called after all agent steps complete successfully. This hook is invoked for **all strategy categories** (`"agent"`, `"rag"`, `"workflow"`, `"agent-mixed"`) and can be used for:
 
-- `user_input`: The original user input
-- `original_context`: Complete message context including system message, memory, and user query
-- `chat_object`: Reference to the chat object for yielding responses
-
-## Best Practices
-
-1. **Choose the Right Category**: Select the strategy category that best matches your use case
-2. **Leverage Framework Features**: Use built-in features like tool calling limits, error handling, and response streaming
-3. **Handle Errors Gracefully**: Implement proper error handling in your strategy methods
-4. **Use Built-in Strategies When Possible**: Start with `ReActAgentStrategy` before creating custom implementations
-5. **Test Thoroughly**: Ensure your strategy handles edge cases and error conditions properly
-
-## Example: Custom RAG Strategy
+- Adding final instructions to the context
+- Context summarization or cleanup
+- Final validation before completion
 
 ```python
-from amrita_core.agent.strategy import AgentStrategy
-from typing import Literal
-
-class RAGStrategy(AgentStrategy):
-    async def run(self) -> None:
-        # Retrieve relevant documents based on user query
-        documents = self.retrieve_documents(self.ctx.user_input)
-
-        # Construct context with retrieved documents
-        rag_context = f"Based on the following documents:\n{documents}\n\nUser query: {self.ctx.user_input}"
-
-        # Update the message context
-        self.ctx.original_context.train.content += f"\n\nRetrieved context: {rag_context}"
-
-        # Let the framework handle the rest
-        pass
-
-    @classmethod
-    def get_category(cls) -> Literal["rag"]:
-        return "rag"
+async def on_post_process(self) -> None:
+    """Called after successful agent execution"""
+    if self.call_count >= 2:  # Only if tools were actually called
+        self.ctx.message.append(
+            Message(
+                role="user",
+                content="<END_OF_PROCESS>\nPlease answer me directly by the informations we got before.\n<END_OF_PROCESS>"
+            )
+        )
 ```

--- a/docs/guide/concepts/agent-strategy.md
+++ b/docs/guide/concepts/agent-strategy.md
@@ -204,7 +204,7 @@ async def on_post_process(self) -> None:
         self.ctx.message.append(
             Message(
                 role="user",
-                content="<END_OF_PROCESS>\nPlease answer me directly by the informations we got before.\n<END_OF_PROCESS>"
+                content="<END_OF_PROCESS>\nPlease answer me directly based on the information we got before.\n<END_OF_PROCESS>"
             )
         )
 ```

--- a/docs/guide/concepts/suspend.md
+++ b/docs/guide/concepts/suspend.md
@@ -44,10 +44,10 @@ async def external_controller(chat_obj):
     # Wait for the "single_tool_call" breakpoint
     await chat_obj.wait_to_suspend(timeout=5.0, tag="single_tool_call")
     print("Suspended before tool call!")
-    
+
     # Can inspect or modify state here
     # ...
-    
+
     chat_obj.resume()
 
 # Start controller task
@@ -70,7 +70,7 @@ class MyAgent:
         async with aiohttp.ClientSession() as session:
             async with session.get(url) as response:
                 return await response.json()
-    
+
     @ChatObject.suspend_with_tag("after_response")
     async def post_process_response(self, chat_obj: ChatObject, response: str):
         """Suspends after processing response"""
@@ -90,15 +90,15 @@ async def multi_breakpoint_controller(chat_obj):
     # Wait for first breakpoint
     await chat_obj.wait_to_suspend(tag="step1")
     print("Step 1 completed")
-    
+
     # Continue waiting for second breakpoint
     await chat_obj.wait_to_suspend(tag="step2")
     print("Step 2 completed")
-    
+
     # Finally wait for any breakpoint
     await chat_obj.wait_to_suspend()  # Matches any suspend-decorated method
     print("Any step completed")
-    
+
     chat_obj.resume()
 ```
 

--- a/docs/guide/function-implementation.md
+++ b/docs/guide/function-implementation.md
@@ -85,7 +85,45 @@ import asyncio
 asyncio.run(load_amrita())
 ```
 
-## 4.2 Conversation Interaction Flow
+## 4.2 Agent Strategy Lifecycle Methods
+
+Agent strategies in AmritaCore implement several lifecycle methods that are called at different points during execution.
+
+### 4.2.1 on_post_process() Post-Process Hook
+
+The `on_post_process()` method is a **post-execution hook** that is called after all agent steps complete successfully. This hook is invoked for **all strategy categories** (`"agent"`, `"rag"`, `"workflow"`, `"agent-mixed"`).
+
+**Purpose**: This hook allows strategies to perform final context modifications, add completion instructions, or perform cleanup operations before the final response is generated.
+
+**Usage Example**:
+
+```python
+async def on_post_process(self) -> None:
+    """Called after successful agent execution"""
+    if self.call_count >= 2:  # Only if tools were actually called
+        self.ctx.message.append(
+            Message(
+                role="user",
+                content="<END_OF_PROCESS>\nPlease answer me directly by the informations we got before.\n<END_OF_PROCESS>"
+            )
+        )
+```
+
+**Key Characteristics**:
+
+- Called only on successful execution (no exceptions occurred)
+- Available for **all strategy categories**
+- Can modify the conversation context before final completion
+- Useful for adding final instructions or context summarization
+
+### 4.2.2 Other Lifecycle Methods
+
+- **`run()`**: Main execution method for `"workflow"` and `"rag"` categories
+- **`single_execute()`**: Single-step execution method for `"agent"` and `"agent-mixed"` categories
+- **`on_exception()`**: Called when an exception occurs during execution
+- **`on_limited()`**: Called when execution limits are reached (e.g., maximum tool calls)
+
+## 4.3 Conversation Interaction Flow
 
 ### 4.2.1 Creating ChatObject Conversation Objects
 
@@ -200,7 +238,7 @@ async with ChatObject(
 context = chat.data
 ```
 
-## 4.3 Event Processing Implementation
+## 4.4 Event Processing Implementation
 
 ### 4.3.1 @on_event Event Listeners
 
@@ -252,7 +290,7 @@ async def postprocess_response(event: CompletionEvent):
 - Ensure event handlers are async when performing async operations
 - Return the event object from handlers to continue the chain
 
-## 4.4 Tool Calling Implementation
+## 4.5 Tool Calling Implementation
 
 ### 4.4.1 Tool Registration Example
 
@@ -400,7 +438,7 @@ In custom run mode:
 - Functions can be synchronous or asynchronous
 - Return type can be `str` or `None`
 
-## 4.5 Memory Management
+## 4.6 Memory Management
 
 ### 4.5.1 MemoryModel Memory Structure
 
@@ -468,7 +506,7 @@ long_convo_config = AmritaConfig(
 - Implement session cleanup strategies
 - Monitor token usage regularly
 
-## 4.6 Logging and Debugging
+## 4.7 Logging and Debugging
 
 ### 4.6.1 Logger Logging System
 

--- a/docs/guide/function-implementation.md
+++ b/docs/guide/function-implementation.md
@@ -104,7 +104,7 @@ async def on_post_process(self) -> None:
         self.ctx.message.append(
             Message(
                 role="user",
-                content="<END_OF_PROCESS>\nPlease answer me directly by the informations we got before.\n<END_OF_PROCESS>"
+                content="<END_OF_PROCESS>\nPlease answer me directly based on the information we got before.\n<END_OF_PROCESS>"
             )
         )
 ```

--- a/docs/guide/getting-started/architecture.md
+++ b/docs/guide/getting-started/architecture.md
@@ -183,4 +183,4 @@ sequenceDiagram
 
 5. **Vendor Neutrality**: The adapter layer ensures that the same agent logic can work with different LLM providers without code changes.
 
-6. **Template Support**: [Jinja2 templates](/guide/concepts/jinja2-templates.md) enable dynamic prompt construction based on context, memory, and configuration.
+6. **Template Support**: [Jinja2 templates](/guide/extensions-integration/jinja2-templates) enable dynamic prompt construction based on context, memory, and configuration.

--- a/docs/zh/guide/api-reference/classes/AgentStrategy.md
+++ b/docs/zh/guide/api-reference/classes/AgentStrategy.md
@@ -79,3 +79,25 @@ AgentStrategy 抽象基类定义了 agent 应如何执行其工作流。
 **参数**:
 
 - `exc` (BaseException): 执行期间发生的异常
+
+### on_post_process()
+
+执行后钩子，在所有 agent 步骤成功完成后调用。
+
+此方法对**所有策略类别**（`"agent"`、`"rag"`、`"workflow"`、`"agent-mixed"`）都可用，且仅在执行成功完成（无异常发生）时调用。
+
+**返回**: None
+
+**用法**: 此钩子可用于在生成最终响应之前执行最终上下文修改、添加完成指令或执行清理操作。
+
+```python
+async def on_post_process(self) -> None:
+    """在成功 agent 执行后调用"""
+    if self.call_count >= 2:  # 仅在实际调用了工具时
+        self.ctx.message.append(
+            Message(
+                role="user",
+                content="<END_OF_PROCESS>\n请根据我们之前获得的信息直接回答我。\n<END_OF_PROCESS>"
+            )
+        )
+```

--- a/docs/zh/guide/api-reference/classes/BaseReActAgentStrategy.md
+++ b/docs/zh/guide/api-reference/classes/BaseReActAgentStrategy.md
@@ -1,0 +1,134 @@
+# BaseReActAgentStrategy
+
+`BaseReActAgentStrategy` 是一个用于ReAct Agent策略的抽象基类，为统一执行流程实现了模板方法模式。
+
+此类为ReAct风格的Agent提供共享功能，包括工具调用编排、推理消息生成、循环检测和通用错误处理模式。
+
+## 继承关系
+
+- 继承自: [AgentStrategy](AgentStrategy.md)
+- 抽象基类: 是
+
+## 属性
+
+- `agent_last_step` (str | None): 跟踪最后的推理步骤或执行的操作
+- `call_count` (int): 工具调用迭代计数器
+- `tools` (list[Any]): Agent可用的工具列表
+- `origin_msg` (str): 原始用户消息内容
+- `origin_instruction` (str): 来自训练上下文的系统指令
+- `reasoning_pc` (int): 用于循环检测的推理过程计数器
+- `_suggested_stop` (bool): 指示是否将tool_choice切换到自动模式的标志
+
+## 构造函数参数
+
+- `ctx` ([StrategyContext](StrategyContext.md)): 包含chat_object、配置和消息上下文的策略上下文
+
+## 模板方法模式
+
+`BaseReActAgentStrategy` 实现了模板方法模式，其中通用执行流程在 `_execute_tool_loop()` 中定义，但策略特定的行为被委托给抽象方法：
+
+### 抽象方法（必须由子类实现）
+
+#### \_append_tool_result_to_context()
+
+将工具结果附加到上下文（策略特定）。
+
+**参数**:
+
+- `tool_call` ([ToolCall](ToolCall.md)): 工具调用对象
+- `func_response` (str): 函数执行结果
+- `response_msg` ([UniResponse](UniResponse.md)): 原始响应消息
+
+#### \_handle_error_append()
+
+处理将错误消息附加到上下文（策略特定）。
+
+**参数**:
+
+- `function_name` (str): 失败函数的名称
+- `error_content` (str): 要附加的格式化错误消息
+- `tool_call_id` (str): 工具调用的ID
+- `original_exception` (BaseException): 用于类型处理的原始异常对象
+
+#### \_append_reasoning()
+
+将推理内容附加到上下文（策略特定）。
+
+**参数**:
+
+- `response` ([UniResponse](UniResponse.md)): 包含推理工具调用的来自tools_caller的响应
+
+### 具体方法（可由子类重写）
+
+#### \_build_stop_response()
+
+构建停止工具响应消息。
+
+**参数**:
+
+- `function_args` (dict[str, Any]): 传递给停止工具的参数
+
+**返回**: str - 用于最终答案生成的指令消息
+
+#### \_check_and_handle_loop_reasoning()
+
+检查是否超过循环推理阈值并构建提示。
+
+**返回**: str | None - 如果超过阈值则返回循环检测提示，否则返回None
+
+#### \_notify_tool_calls()
+
+向用户发送工具调用完成通知。
+
+**参数**:
+
+- `result_msg_list` (list[[ToolResult](ToolResult.md)]): 要通知的工具结果列表
+- `function_name` (str): 被调用函数的名称
+- `tool_call_id` (str): 工具调用的ID
+
+#### \_handle_loop_reasoning_cleanup()
+
+在检测到循环推理时清理策略特定状态。
+
+**参数**:
+
+- `prompt` (str): 循环检测提示消息
+
+#### \_build_stop_response_and_append()
+
+构建停止响应并附加到消息列表（策略特定）。
+
+**参数**:
+
+- `function_args` (dict[str, Any]): 传递给停止工具的参数
+- `response_msg` ([UniResponse](UniResponse.md)): 原始响应消息
+
+## 使用方法
+
+此类不应直接实例化。相反，应创建实现所需抽象方法的子类：
+
+```python
+from amrita_core.builtins.agent import BaseReActAgentStrategy
+
+class MyCustomReActStrategy(BaseReActAgentStrategy):
+    async def _append_tool_result_to_context(self, tool_call, func_response, response_msg):
+        # 实现策略特定的工具结果处理
+        pass
+
+    async def _handle_error_append(self, function_name, error_content, tool_call_id, original_exception):
+        # 实现策略特定的错误处理
+        pass
+
+    async def _append_reasoning(self, response):
+        # 实现策略特定的推理处理
+        pass
+
+    @classmethod
+    def get_category(cls):
+        return "agent-mixed"
+```
+
+## 内置子类
+
+- [ReActAgentStrategy](ReActAgentStrategy.md): 具有OpenAI兼容ToolCall-ToolResult配对的标准实现
+- [HybridReActAgentStrategy](HybridReActAgentStrategy.md): 使用XML标签的MoE架构模型专用实现

--- a/docs/zh/guide/api-reference/classes/HybridReActAgentStrategy.md
+++ b/docs/zh/guide/api-reference/classes/HybridReActAgentStrategy.md
@@ -1,0 +1,92 @@
+# HybridReActAgentStrategy
+
+`HybridReActAgentStrategy` 是一种专门针对**混合专家（MoE）架构模型**优化的Agent策略。
+
+此策略解决了某些MoE模型在区分工具和完成标识符时内部状态机的模糊性问题。与依赖显式ToolCall-ToolResult交互的传统工具链方法不同，这种混合方法使用ToolCall触发结合将纯文本直接附加到上下文。
+
+## 继承关系
+
+- 继承自: [BaseReActAgentStrategy](BaseReActAgentStrategy.md)
+- 类别: `"agent-mixed"`
+
+## 关键特性
+
+- **ToolCall触发**: 通过标准ToolCall机制启动工具执行
+- **基于上下文的集成**: 将工具结果作为纯文本消息附加，而不是结构化的ToolResult对象
+- **XML标签格式**: 使用 `<TOOL_CALL>` 和 `<TOOL_RESULT>` XML标签表示工具交互
+- **MoE特定优化**: 解决MoE模型在区分工具调用状态和完成状态时遇到的问题
+
+## 属性
+
+- `regexes` (ClassVar[list[tuple[re.Pattern, str]]]): 用于XML标签清理的正则表达式
+- `_tool_call_jinja2` ([Template](https://jinja.palletsprojects.com/)): 用于渲染工具调用和结果的Jinja2模板
+- `_process_message` (list[str]): 处理工具消息的临时存储
+
+## 构造函数参数
+
+- `ctx` ([StrategyContext](StrategyContext.md)): 包含chat_object、配置和消息上下文的策略上下文
+
+## 工具函数模式
+
+```xml
+<!-- 工具调用 -->
+<TOOL_CALL name="tool">
+    <PARAMS>
+        <!-- 参数作为键值对传递 -->
+        <PARAM name="param1">value1</PARAM>
+    </PARAMS>
+</TOOL_CALL>
+
+<!-- 工具结果 -->
+<TOOL_RESULT name="tool">
+   工具执行结果内容
+</TOOL_RESULT>
+```
+
+## 安全考虑
+
+**⚠️ 重要安全警告**:
+
+- **提示注入风险**: 将工具结果作为纯 `user` 消息附加可能会在工具输出不可信或未清理时使模型暴露于注入攻击
+- **最小化清理**: 此策略仅提供基本的标签对转义，**不执行**语义级过滤或内容验证
+- **安全责任**: 用户**必须**在生产环境中为工具结果实现全面的输入验证、语义分析和内容清理
+
+## 使用示例
+
+```python
+import asyncio
+from amrita_core import create_agent, minimal_init
+from amrita_core.builtins.agent import HybridReActAgentStrategy
+
+async def use_hybrid_strategy():
+    # 初始化AmritaCore
+    await minimal_init()
+
+    # 为MoE模型创建带有混合策略的Agent
+    agent = create_agent(
+        url="https://api.moemodel.com",
+        key="your-api-key",
+        strategy=HybridReActAgentStrategy
+    )
+
+    # 使用Agent
+    chat = agent.get_chatobject("使用可用工具分析这些数据")
+    async with chat.begin():
+        response = await chat.full_response()
+```
+
+## 何时使用
+
+当使用以下情况时使用 `HybridReActAgentStrategy`：
+
+- **混合专家（MoE）模型**，如Mixtral、Qwen-MoE等
+- 模型在处理标准ToolCall-ToolResult消息对时表现出不一致行为
+- 场景中模型的内部状态机难以区分工具调用和完成状态
+
+## 何时不使用
+
+避免使用 `HybridReActAgentStrategy` 当：
+
+- 使用标准LLM提供商（OpenAI、Anthropic等）- 改用 [ReActAgentStrategy](ReActAgentStrategy.md)
+- 安全是主要关注点且无法实现适当的输入验证
+- 需要严格的OpenAI兼容消息格式

--- a/docs/zh/guide/api-reference/classes/NoActionAgentStrategy.md
+++ b/docs/zh/guide/api-reference/classes/NoActionAgentStrategy.md
@@ -1,0 +1,63 @@
+# NoActionAgentStrategy
+
+`NoActionAgentStrategy` 是一个执行无操作的简单工作流策略。当需要放弃工具调用过程时可以使用。
+
+## 继承关系
+
+- 继承自: [AgentStrategy](AgentStrategy.md)
+- 类别: `"workflow"`
+
+## 构造函数参数
+
+- `ctx` ([StrategyContext](StrategyContext.md)): 包含chat_object、配置和消息上下文的策略上下文
+
+## 方法
+
+### run()
+
+无操作实现，立即返回而不执行任何操作。
+
+**返回**: None
+
+### on_exception()
+
+无操作异常处理程序，立即返回而不执行任何操作。
+
+**参数**:
+
+- `exc` (BaseException): 发生的异常
+
+**返回**: None
+
+## 使用示例
+
+```python
+import asyncio
+from amrita_core import create_agent, minimal_init
+from amrita_core.builtins.agent import NoActionAgentStrategy
+
+async def use_no_action_strategy():
+    # 初始化AmritaCore
+    await minimal_init()
+
+    # 创建带有无操作策略的Agent以跳过工具执行
+    agent = create_agent(
+        url="https://api.example.com",
+        key="your-api-key",
+        strategy=NoActionAgentStrategy
+    )
+
+    # 使用Agent - 它将直接响应而不调用工具
+    chat = agent.get_chatobject("直接回应此查询")
+    async with chat.begin():
+        response = await chat.full_response()
+```
+
+## 何时使用
+
+当以下情况时使用 `NoActionAgentStrategy`：
+
+- 想要完全跳过工具执行
+- 需要一个没有工具调用逻辑的简单直接响应
+- 实现条件逻辑，其中在某些场景下应绕过工具调用
+- 需要用于测试或调试目的的占位符策略

--- a/docs/zh/guide/builtins.md
+++ b/docs/zh/guide/builtins.md
@@ -49,23 +49,24 @@ AmritaCore 提供了多个LLM提供商的内置适配器，实现了 `ModelAdapt
 
 **功能特性**：
 
-- **API调用**: 异步调用OpenAI兼容API获取聊天回复
-- **流式响应**: 支持流式响应以实现实时内容输出，并包含用量统计
+- **API调用**: 异步调用OpenAI兼容API以获取聊天响应
+- **流式响应**: 支持流式响应，实现实时内容输出和使用统计
 - **工具调用**: 完全支持OpenAI的函数调用功能，具有适当的工具选择处理
-- **用量统计**: 跟踪API调用用量信息，包括令牌计数
+- **使用统计**: 跟踪API调用使用信息，包括令牌计数
 - **错误处理**: 具有可配置重试逻辑的健壮错误处理
 
 **支持的协议**: `"openai"`, `"__main__"`
 
 ### 9.2.2 AnthropicAdapter (实验性)
 
-`AnthropicAdapter` 提供对Anthropic Claude模型的实验性支持。
+`AnthropicAdapter` 为Anthropic的Claude模型提供实验性支持。
 
 **功能特性**：
 
 - **API调用**: 异步调用Anthropic API
 - **流式响应**: 支持带有消息流处理的流式响应
-- **令牌跟踪**: 针对Anthropic用量模型的正确输入/输出令牌跟踪
+- **令牌跟踪**: 为Anthropic的使用模型提供适当的输入/输出令牌跟踪
+- **消息过滤**: 自动过滤无效消息（content=None的assistant消息和所有tool消息），以符合Anthropic API要求
 
 **支持的协议**: `"anthropic"`, `"claude"`
 
@@ -73,146 +74,125 @@ AmritaCore 提供了多个LLM提供商的内置适配器，实现了 `ModelAdapt
 
 ## 9.3 内置Agent系统
 
-AmritaCore 包含一个全面的智能体系统，能够自主使用工具完成任务。
+AmritaCore包含一个全面的智能Agent系统，能够自主使用工具完成任务。该系统通过**模板方法模式**架构得到了显著增强，提供了统一的执行流程，同时允许策略特定的自定义。
 
-### 9.3.1 ReActAgentStrategy
+### 9.3.1 BaseReActAgentStrategy (抽象基类)
 
-`ReActAgentStrategy` 是内置的Agent策略，实现了 `"agent-mixed"` 类别，支持在同一执行框架内同时处理检索增强生成（RAG）和迭代工具调用。
+`BaseReActAgentStrategy` 是实现ReAct风格Agent模板方法模式的抽象基类。它提供共享功能包括：
 
-**关键特性**：
+- **工具调用编排**和执行流程控制
+- **推理消息生成**和处理
+- **循环检测和恢复机制**（检测过多的重复推理调用）
+- **工具调用通知处理**，具有可配置的用户通知
+- **通用错误处理模式**，具有适当的异常管理
+- **统一的停止状态管理**，通过 `_suggested_stop` 标志
+
+这个抽象类定义了所有ReAct风格策略继承的通用执行框架，确保行为一致性，同时通过抽象方法允许自定义。
+
+### 9.3.2 ReActAgentStrategy
+
+`ReActAgentStrategy` 是标准实现，继承自 `BaseReActAgentStrategy` 并实现 `"agent-mixed"` 类别，支持在同一执行框架内同时进行检索增强生成（RAG）和迭代工具调用。
+
+**主要特性**：
 
 - **动态模式切换**: 根据配置自动在RAG和Agent模式之间适应
 - **内置工具集成**: 无缝集成所有内置工具（`STOP_TOOL`、`REASONING_TOOL`、`PROCESS_MESSAGE`）
-- **推理支持**: 可选的推理步骤生成（在工具执行前）
-- **错误处理**: 具有用户通知的全面错误处理
+- **标准ToolCall-ToolResult配对**: 严格遵守OpenAI兼容的消息格式
+- **推理支持**: 可选的推理步骤生成，用于工具执行前
+- **错误处理**: 全面的错误处理，具有用户通知
 - **会话管理**: 具有内存保留的完整会话状态管理
 
 **配置选项**：
 
 - **工具调用模式**: 通过 `config.builtin.tool_calling_mode` 配置（`"agent"`、`"rag"`、`"none"`）
-- **思维模式**: 通过 `config.builtin.agent_thought_mode` 配置（`"reasoning"`、`"reasoning-required"` 等）
+- **思维模式**: 通过 `config.builtin.agent_thought_mode` 配置（`"reasoning"`、`"reasoning-required"`等）
 - **工具调用限制**: 通过调用计数自动防止无限循环
 - **中间消息**: 控制处理消息和推理步骤的可见性
 - **错误通知**: 可配置的错误报告给用户
 
-### 9.3.2 Agent工作流程
+### 9.3.3 HybridReActAgentStrategy
 
-内置Agent系统遵循以下增强的工作流程：
+`HybridReActAgentStrategy` 是一种专门针对**混合专家（MoE）架构模型**优化的Agent策略。它解决了某些MoE模型在区分工具和完成标识符时内部状态机的模糊性问题。
 
-1. **初始化**: 使用 `create_agent()` 或 `AgentRuntime` 创建Agent
-2. **上下文设置**: 使用系统提示和内存初始化对话上下文
-3. **模式检测**: 根据配置确定执行模式（RAG vs Agent）
-4. **推理阶段** (可选): 如果启用了思维模式，则生成推理步骤
-5. **工具选择**: 根据当前情况和可用工具选择适当的工具
-6. **工具执行**: 执行选定的工具并进行适当的错误处理
-7. **结果处理**: 处理工具结果并更新对话上下文
-8. **迭代控制**: 管理迭代限制和终止条件
-9. **结束**: 使用 `STOP_TOOL` 结束任务或提供最终响应
+**关键特性**：
 
-### 9.3.3 核心API函数
+- **ToolCall触发**: 通过标准ToolCall机制启动工具执行
+- **基于上下文的集成**: 将工具结果作为纯文本消息附加，而不是结构化的ToolResult对象，避免MoE模型状态模糊
+- **XML标签格式**: 使用 `<TOOL_CALL>` 和 `<TOOL_RESULT>` XML标签表示工具交互
+- **MoE特定优化**: 解决MoE模型在区分工具调用状态和完成状态时遇到的问题
 
-AmritaCore 提供了用于简化Agent创建的高级工厂函数：
+**工具函数模式**：
 
-#### create_agent()
+```xml
+<!-- 工具调用 -->
+<TOOL_CALL name="tool">
+    <PARAMS>
+        <!-- 参数作为键值对传递 -->
+        <PARAM name="param1">value1</PARAM>
+    </PARAMS>
+</TOOL_CALL>
 
-一个工厂函数，使用最少的参数创建 `AgentRuntime` 实例：
-
-```python
-from amrita_core import create_agent, minimal_init
-
-async def example():
-    await minimal_init()
-    agent = create_agent(
-        base_url="https://api.example.com",
-        api_key="your-api-key",
-        model="gpt-4",
-        model_config={"temperature": 0.7}
-    )
-    chat = agent.get_chatobject("What can you do?")
-    async with chat.begin():
-        response = await chat.full_response()
-    return response
+<!-- 工具结果 -->
+<TOOL_RESULT name="tool">
+   工具执行结果内容
+</TOOL_RESULT>
 ```
 
-**参数**：
+**已知限制和安全考虑**：
 
-- `base_url`: API端点URL
-- `api_key`: 认证API密钥
-- `model`: 模型名称（默认为"auto"）
-- `train`: 自定义系统提示（可选）
-- `model_config`: 模型配置参数
-- `config`: Amrita配置对象（可选）
+- **提示注入风险**: 将工具结果作为纯 `user` 消息附加可能会在工具输出不可信或未清理时使模型暴露于注入攻击
+- **最小化清理**: 此策略仅提供基本的标签对转义，**不执行**语义级过滤或内容验证
+- **安全责任**: 用户**必须**在生产环境中为工具结果实现全面的输入验证、语义分析和内容清理
 
-#### AgentRuntime
+### 9.3.4 NoActionAgentStrategy
 
-提供对Agent配置完全控制的底层运行时类：
+`NoActionAgentStrategy` 是一个简单的工作流策略，不执行任何操作。当需要放弃工具调用过程时可以使用。
 
-```python
-from amrita_core import AgentRuntime, minimal_init
-from amrita_core.config import get_config
-from amrita_core.types import ModelPreset, ModelConfig
+- **类别**: `"workflow"`
+- **用例**: 当您需要完全跳过工具执行时
+- **实现**: 空的 `run()` 方法，立即返回
 
-async def advanced_example():
-    await minimal_init()
-    config = get_config()
-    preset = ModelPreset(
-        name="custom_preset",
-        base_url="https://api.example.com",
-        api_key="your-api-key",
-        model="gpt-4",
-        config=ModelConfig(temperature=0.7, stream=True)
-    )
+### 9.3.5 Agent工作流和模板方法模式
 
-    agent = AgentRuntime(
-        config=config,
-        preset=preset,
-        train={"content": "你是一个乐于助人的助手。", "role": "system"}
-    )
+内置Agent系统遵循使用模板方法模式的增强工作流：
 
-    chat = agent.get_chatobject("你好！")
-    async with chat.begin():
-        async for chunk in chat.get_response_generator():
-            print(chunk, end="")
-```
+1. **初始化**: 使用用户输入和对话历史创建策略上下文
+2. **工具准备**: 根据配置确定可用工具
+3. **推理阶段**（可选）: 如果配置了，则生成推理步骤
+4. **工具执行循环**：
+   - 基于模型决策调用工具
+   - 根据策略特定逻辑处理结果
+   - 循环检测防止无限推理循环
+5. **后处理**: 调用 `on_post_process()` 钩子进行最终上下文修改
+6. **完成**: 生成最终响应
 
-## 9.4 内置安全特性
+模板方法模式确保步骤1-4和6在所有策略中遵循一致的流程，而步骤5（结果处理）和错误处理则根据策略实现进行自定义。
 
-### 9.4.1 Cookie安全检测
+### 9.3.6 策略选择指南
 
-AmritaCore 包含内置的Cookie安全检测，以防止提示注入攻击：
+根据您的用例选择合适的内置策略：
 
-- **自动Cookie生成**: 为每个会话自动生成唯一Cookie
-- **泄露检测**: 监控响应中是否存在Cookie，以指示潜在的注入攻击
-- **自动响应阻止**: 阻止包含Cookie的响应并返回错误消息
+- **标准LLM提供商**（OpenAI、Anthropic等）: 使用 `ReActAgentStrategy`
+- **MoE架构模型**（Mixtral、Qwen-MoE等）: 使用 `HybridReActAgentStrategy`
+- **跳过工具执行**: 使用 `NoActionAgentStrategy`
+- **自定义行为**: 扩展 `BaseReActAgentStrategy` 或实现您自己的 `AgentStrategy`
 
-### 9.4.2 会话隔离
+## 9.4 内置事件钩子
 
-内置的会话管理确保不同用户或对话之间的完全隔离：
+AmritaCore为常见场景提供内置事件钩子：
 
-- **SessionsManager**: 管理会话生命周期的单例类
-- **SessionData**: 每个会话的配置、工具和内存
-- **自动清理**: 会话在不再需要时自动清理
+### 9.4.1 Cookie安全钩子
 
-## 9.5 内置事件系统
+Cookie安全钩子自动检测模型响应中是否出现敏感Cookie值，并终止会话以防止数据泄露。
 
-AmritaCore 提供了一个全面的事件驱动架构，具有内置的事件处理器：
+- **激活**: 当 `config.cookie.enable_cookie = True` 时启用
+- **检测**: 扫描模型响应中的配置Cookie值
+- **响应**: 检测到时终止会话并返回通用错误消息
 
-### 9.5.1 PreCompletionEvent
+### 9.4.2 后处理钩子
 
-在向LLM发送请求之前触发，允许修改消息和切换预设。
+`on_post_process()` 钩子在策略执行成功后调用，可用于最终上下文修改或清理操作。
 
-### 9.5.2 CompletionEvent
-
-在从LLM接收响应后触发，支持响应处理和安全检查。
-
-### 9.5.3 FallbackContext
-
-处理LLM请求失败，具有自动重试逻辑和预设回退机制。
-
-### 9.5.4 内置事件处理器
-
-- **Cookie安全处理器**: 自动检查响应中的Cookie泄露
-- **工具调用通知**: 提供工具执行状态的实时反馈
-- **错误传播**: 确保跨执行管道的适当错误处理
-
-这些内置功能为开发复杂的AI代理提供了坚实的基础，同时保持安全性、性能和可扩展性。
+- **时机**: 在所有工具执行成功完成后调用
+- **适用性**: 对**所有策略类别**（`"agent"`、`"rag"`、`"workflow"`、`"agent-mixed"`）都可用
+- **用例**: 添加最终指令、上下文摘要或清理操作

--- a/docs/zh/guide/concepts/agent-strategy.md
+++ b/docs/zh/guide/concepts/agent-strategy.md
@@ -1,59 +1,120 @@
 # Agent 策略
 
-## 理解 Agent 策略架构
+## 理解Agent策略架构
 
-AmritaCore 实现了灵活的 Agent 策略架构，允许 AI agent 采用不同的执行模式。核心概念是将 agent 行为逻辑与底层执行框架分离，使开发者能够创建自定义 agent 行为，同时利用 AmritaCore 提供的强大基础设施。
+AmritaCore实现了灵活的Agent策略架构，允许为AI Agent使用不同的执行模式。核心概念是将Agent行为逻辑与底层执行框架分离，使开发人员能够创建自定义Agent行为，同时利用AmritaCore提供的强大基础设施。
 
 ### 策略类别
 
-AmritaCore 支持四种不同的策略类别，每种类别都针对特定用例设计：
+AmritaCore支持四种不同的策略类别，每种类别都针对特定用例设计：
 
-#### 1. Agent 类别 (`"agent"`)
+#### 1. Agent类别 (`"agent"`)
 
 - **执行方法**: `single_execute()`
-- **框架控制**: 完全由框架管理执行循环、调用计数和终止条件
-- **使用场景**: 需要框架级控制的标准工具调用 agent
-- **上下文**: 包含系统消息、记忆和用户查询的完整对话历史
+- **框架控制**: 完整的框架管理执行循环、调用计数和终止
+- **用例**: 需要框架级控制的标准工具调用Agent
+- **上下文**: 包含系统消息、内存和用户查询的完整对话历史
 
-#### 2. RAG 类别 (`"rag"`)
+#### 2. RAG类别 (`"rag"`)
 
 - **执行方法**: `run()`
 - **框架控制**: 仅最小上下文（系统消息 + 用户查询）
-- **使用场景**: 检索增强生成场景，其中外部知识检索是主要功能
+- **用例**: 外部知识检索为主要目的的检索增强生成场景
 - **上下文**: 仅系统消息和用户查询，无历史对话上下文
 
-#### 3. Workflow 类别 (`"workflow"`)
+#### 3. 工作流类别 (`"workflow"`)
 
 - **执行方法**: `run()`
 - **框架控制**: 对所有内容的完全手动控制
-- **使用场景**: 具有自定义编排逻辑的复杂多步骤工作流
-- **上下文**: 具有完全手动管理的完整对话历史
+- **用例**: 具有自定义编排逻辑的复杂多步骤工作流
+- **上下文**: 具有完整手动管理的完整对话历史
 
-#### 4. Agent-Mixed 类别 (`"agent-mixed"`)
+#### 4. Agent混合类别 (`"agent-mixed"`)
 
 - **执行方法**: `single_execute()`
-- **框架控制**: 框架管理的执行，具有动态模式切换
-- **使用场景**: 需要根据上下文在 RAG 和迭代工具调用之间适应的 agent
+- **框架控制**: 具有动态模式切换的框架管理执行
+- **用例**: 需要根据上下文在RAG和迭代工具调用之间适应的Agent
 - **上下文**: 具有动态行为适应的完整对话历史
+
+### 模板方法模式架构
+
+AmritaCore的Agent策略系统通过**模板方法模式**得到了增强，该模式提供了统一的执行框架，同时允许策略特定的自定义。
+
+`BaseReActAgentStrategy` 抽象基类定义了通用执行流程：
+
+1. **工具调用生成**: 模型基于当前上下文生成工具调用
+2. **工具执行循环**: 每个工具调用都通过标准化流程处理
+3. **结果处理**: 策略特定逻辑处理如何将结果添加到上下文
+4. **循环检测**: 自动检测和处理推理循环
+5. **错误处理**: 具有策略特定恢复的通用错误模式
+6. **后处理**: 可选的 `on_post_process()` 钩子用于最终修改
+
+这种模式确保所有ReAct风格策略的行为一致性，同时通过抽象方法（如 `_append_tool_result_to_context()` 和 `_handle_error_append()`）允许自定义。
 
 ### 统一工具接口
 
-所有 agent 策略都从基类 `AgentStrategy` 继承 `call_tool()` 方法。这提供了一个**统一的工具执行接口**，确保 AmritaCore 中所有策略实现的一致性。
+所有Agent策略都从基类 `AgentStrategy` 继承 `call_tool()` 方法。这提供了**统一的工具执行接口**，确保AmritaCore中所有策略实现的一致性。
 
 统一工具接口的关键特性：
 
-- **单步执行**: 每次调用只执行一个工具，不修改 agent 的内部上下文
-- **一致的错误处理**: 在管理器中找不到的工具会抛出 `RuntimeError`
-- **标准化的响应格式**: 返回字符串响应或为 None 返回默认消息
-- **ToolContext 集成**: 支持简单的函数调用和具有上下文访问的高级工具实现
+- **单步执行**: 每次调用恰好执行一个工具，不修改Agent的内部上下文
+- **一致的错误处理**: 在管理器中找不到的工具会引发 `RuntimeError`
+- **标准化响应格式**: 返回字符串响应或None返回的默认消息
+- **ToolContext集成**: 支持简单的函数调用和具有上下文访问的高级工具实现
 
-这个统一接口保证了无论您实现哪种策略类别，工具调用行为在整个 AmritaCore 生态系统中都保持一致和可预测。
+这种统一接口保证了无论您实现哪种策略类别，工具调用行为在整个AmritaCore生态系统中都保持一致和可预测。
+
+### 内置策略实现
+
+#### ReActAgentStrategy
+
+遵循OpenAI兼容ToolCall-ToolResult配对的标准实现。它保持严格的消息格式合规性，适用于大多数LLM提供商。
+
+#### HybridReActAgentStrategy
+
+针对**混合专家（MoE）架构模型**优化的专门实现。它不使用标准的ToolCall-ToolResult对，而是使用嵌入在对话上下文中的XML标签（`<TOOL_CALL>`、`<TOOL_RESULT>`）作为纯文本消息。
+
+这种方法解决了MoE模型中的状态机模糊问题，但由于潜在的提示注入风险，需要仔细的安全考虑。
+
+#### NoActionAgentStrategy
+
+执行无操作的最小工作流策略，当需要跳过工具执行时很有用。
 
 ## 实现指南
 
-### 创建自定义 Agent 策略
+### 创建自定义Agent策略
 
-要创建自定义 agent 策略，请扩展 `AgentStrategy` 抽象基类并实现所需的方法：
+要创建自定义Agent策略，您有两种选择：
+
+#### 选项1: 扩展 BaseReActAgentStrategy（推荐用于ReAct风格Agent）
+
+```python
+from amrita_core.builtins.agent import BaseReActAgentStrategy
+from typing import Literal
+
+class MyCustomReActStrategy(BaseReActAgentStrategy):
+    def __init__(self, ctx):
+        super().__init__(ctx)
+        # 初始化自定义状态
+
+    async def _append_tool_result_to_context(self, tool_call, func_response, response_msg):
+        # 实现工具结果如何添加到上下文
+        pass
+
+    async def _handle_error_append(self, function_name, error_content, tool_call_id, original_exception):
+        # 实现特定于策略的错误处理
+        pass
+
+    async def _append_reasoning(self, response):
+        # 实现推理步骤处理
+        pass
+
+    @classmethod
+    def get_category(cls) -> Literal["agent-mixed"]:
+        return "agent-mixed"
+```
+
+#### 选项2: 直接扩展 AgentStrategy（用于完全自定义行为）
 
 ```python
 from amrita_core.agent.strategy import AgentStrategy
@@ -66,8 +127,13 @@ class MyCustomAgentStrategy(AgentStrategy):
 
     async def single_execute(self) -> bool:
         # 实现单步执行逻辑
-        # 返回 True 继续，返回 False 停止
+        # 返回True继续，False停止
         return True
+
+    async def on_post_process(self) -> None:
+        # 可选：实现后处理逻辑
+        # 在agent/agent-mixed模式下成功执行后调用
+        pass
 
     @classmethod
     def get_category(cls) -> Literal["agent"]:
@@ -76,73 +142,69 @@ class MyCustomAgentStrategy(AgentStrategy):
 
 ### 使用内置策略
 
-AmritaCore 提供了 `ReActAgentStrategy` 作为内置实现，支持 `"agent-mixed"` 类别：
+AmritaCore为不同用例提供多种内置策略：
 
 ```python
 import asyncio
 from amrita_core import create_agent, minimal_init
-from amrita_core.builtins.agent import ReActAgentStrategy
+from amrita_core.builtins.agent import (
+    ReActAgentStrategy,
+    HybridReActAgentStrategy,
+    NoActionAgentStrategy
+)
 
-async def use_builtin_strategy():
-    # 初始化 AmritaCore
+async def use_builtin_strategies():
+    # 初始化AmritaCore
     await minimal_init()
 
-    # 使用自定义策略创建 agent
-    agent = create_agent(
-        url="https://api.example.com",
+    # 标准ReAct策略（推荐用于大多数情况）
+    standard_agent = create_agent(
+        url="https://api.openai.com",
         key="your-api-key",
         strategy=ReActAgentStrategy
     )
 
-    # 使用 agent
-    chat = agent.get_chatobject("What can you do?")
-    async with chat.begin():
-        response = await chat.full_response()
+    # MoE模型的混合策略
+    hybrid_agent = create_agent(
+        url="https://api.moemodel.com",
+        key="your-api-key",
+        strategy=HybridReActAgentStrategy
+    )
 
-    return response
+    # 跳过工具执行的无操作策略
+    no_action_agent = create_agent(
+        url="https://api.example.com",
+        key="your-api-key",
+        strategy=NoActionAgentStrategy
+    )
 
-# 运行示例
-if __name__ == "__main__":
-    asyncio.run(use_builtin_strategy())
+    # 使用这些Agent
+    chat1 = standard_agent.get_chatobject("你能做什么？")
+    chat2 = hybrid_agent.get_chatobject("分析这些数据")
+    chat3 = no_action_agent.get_chatobject("直接回应")
+
+    async with chat1.begin(), chat2.begin(), chat3.begin():
+        response1 = await chat1.full_response()
+        response2 = await chat2.full_response()
+        response3 = await chat3.full_response()
 ```
 
-## 策略上下文
+### 后处理钩子
 
-`StrategyContext` 为策略执行提供所有必要信息：
+`on_post_process()` 方法是一个新的生命周期钩子，在所有Agent步骤成功完成后调用。此钩子对**所有策略类别**（`"agent"`、`"rag"`、`"workflow"`、`"agent-mixed"`）都可用，可用于：
 
-- `user_input`: 原始用户输入
-- `original_context`: 包含系统消息、记忆和用户查询的完整消息上下文
-- `chat_object`: 用于生成响应的聊天对象引用
-
-## 最佳实践
-
-1. **选择正确的类别**: 选择最适合您用例的策略类别
-2. **利用框架功能**: 使用内置功能如工具调用限制、错误处理和响应流
-3. **优雅地处理错误**: 在策略方法中实现适当的错误处理
-4. **尽可能使用内置策略**: 在创建自定义实现之前，先从 `ReActAgentStrategy` 开始
-5. **彻底测试**: 确保您的策略能正确处理边缘情况和错误条件
-
-## 示例：自定义 RAG 策略
+- 向上下文添加最终指令
+- 上下文摘要或清理
+- 完成前的最终验证
 
 ```python
-from amrita_core.agent.strategy import AgentStrategy
-from typing import Literal
-
-class RAGStrategy(AgentStrategy):
-    async def run(self) -> None:
-        # 根据用户查询检索相关文档
-        documents = self.retrieve_documents(self.ctx.user_input)
-
-        # 使用检索到的文档构建上下文
-        rag_context = f"基于以下文档:\n{documents}\n\n用户查询: {self.ctx.user_input}"
-
-        # 更新消息上下文
-        self.ctx.original_context.train.content += f"\n\n检索到的上下文: {rag_context}"
-
-        # 让框架处理其余部分
-        pass
-
-    @classmethod
-    def get_category(cls) -> Literal["rag"]:
-        return "rag"
+async def on_post_process(self) -> None:
+    """在成功Agent执行后调用"""
+    if self.call_count >= 2:  # 仅在实际调用了工具时
+        self.ctx.message.append(
+            Message(
+                role="user",
+                content="<END_OF_PROCESS>\n请根据我们之前获得的信息直接回答我。\n<END_OF_PROCESS>"
+            )
+        )
 ```

--- a/docs/zh/guide/concepts/suspend.md
+++ b/docs/zh/guide/concepts/suspend.md
@@ -44,10 +44,10 @@ async def external_controller(chat_obj):
     # 等待名为 "single_tool_call" 的断点
     await chat_obj.wait_to_suspend(timeout=5.0, tag="single_tool_call")
     print("在工具调用前挂起！")
-    
+
     # 可以在此检查或修改状态
     # ...
-    
+
     chat_obj.resume()
 
 # 启动控制器任务
@@ -70,7 +70,7 @@ class MyAgent:
         async with aiohttp.ClientSession() as session:
             async with session.get(url) as response:
                 return await response.json()
-    
+
     @ChatObject.suspend_with_tag("after_response")
     async def post_process_response(self, chat_obj: ChatObject, response: str):
         """处理响应后会挂起"""
@@ -90,15 +90,15 @@ async def multi_breakpoint_controller(chat_obj):
     # 先等待第一个断点
     await chat_obj.wait_to_suspend(tag="step1")
     print("步骤 1 完成")
-    
+
     # 继续等待第二个断点
     await chat_obj.wait_to_suspend(tag="step2")
     print("步骤 2 完成")
-    
+
     # 最后等待任意断点
     await chat_obj.wait_to_suspend()  # 匹配任何 suspend 装饰的方法
     print("任意步骤完成")
-    
+
     chat_obj.resume()
 ```
 

--- a/docs/zh/guide/function-implementation.md
+++ b/docs/zh/guide/function-implementation.md
@@ -4,32 +4,32 @@
 
 ### 4.1.1 init() 初始化函数
 
-`init()` 函数初始化 AmritaCore 的核心组件，必须在任何其他操作之前调用：
+`init()` 函数初始化AmritaCore的核心组件，在执行任何其他操作之前必须调用：
 
 ```python
 from amrita_core import init
 
-# 初始化 AmritaCore
+# 初始化AmritaCore
 init()
 ```
 
-此函数执行几个关键任务：
+此函数执行几项关键任务：
 
-- 设置内部日志
-- 初始化 Jieba 用于文本处理（如果可用）
+- 设置内部日志记录
+- 初始化Jieba进行文本处理（如果可用）
 - 加载内置模块
 - 准备核心框架以供使用
 
 ### 4.1.2 load_amrita() 异步加载
 
-`load_amrita()` 函数异步加载 AmritaCore 组件，特别是在启用 MCP 客户端功能时：
+`load_amrita()` 函数异步加载AmritaCore组件，特别是当启用了MCP客户端功能时：
 
 ```python
 import asyncio
 from amrita_core import load_amrita
 
 async def main():
-    # 加载 AmritaCore 组件
+    # 加载AmritaCore组件
     await load_amrita()
 
 asyncio.run(main())
@@ -39,7 +39,7 @@ asyncio.run(main())
 
 #### 4.1.3.1 set_config() 设置配置
 
-`set_config()` 函数将配置应用到 AmritaCore：
+`set_config()` 函数将配置应用到AmritaCore：
 
 ```python
 from amrita_core.config import AmritaConfig, set_config
@@ -49,41 +49,42 @@ config = AmritaConfig()
 set_config(config)
 ```
 
-#### 4.1.3.2 get_config() 检索配置
+## 4.2 Agent策略生命周期方法
 
-`get_config()` 函数检索当前 AmritaCore 配置：
+AmritaCore中的Agent策略实现了几个在执行过程中不同点被调用的生命周期方法。
 
-```python
-from amrita_core.config import get_config
+### 4.2.1 on_post_process() 后处理钩子
 
-# 检索当前配置
-current_config = get_config()
-print(current_config.function_config.use_minimal_context)
-```
+`on_post_process()` 方法是一个**执行后钩子**，在所有Agent步骤成功完成后调用。此钩子对**所有策略类别**（`"agent"`、`"rag"`、`"workflow"`、`"agent-mixed"`）都可用。
 
-### 4.1.4 初始化过程详情
+**目的**: 此钩子允许策略在生成最终响应之前执行最终上下文修改、添加完成指令或执行清理操作。
 
-初始化过程涉及：
+**使用示例**:
+``python
+async def on_post_process(self) -> None:
+"""在成功Agent执行后调用"""
+if self.call_count >= 2: # 仅在实际调用了工具时
+self.ctx.message.append(
+Message(
+role="user",
+content="<END_OF_PROCESS>\n请根据我们之前获得的信息直接回答我。\n<END_OF_PROCESS>"
+)
+)
 
-1. 调用 `init()` 准备核心组件
-2. 使用 `set_config()` 设置所需配置
-3. 使用 `load_amrita()` 加载附加组件
+````
 
-```python
-from amrita_core import init, load_amrita
-from amrita_core.config import AmritaConfig, set_config
+**关键特性**:
+- 仅在成功执行时调用（未发生异常）
+- 对**所有策略类别**都可用
+- 可以在最终完成之前修改对话上下文
+- 适用于添加最终指令或上下文摘要
 
-# 步骤 1: 初始化核心组件
-init()
+### 4.2.2 其他生命周期方法
 
-# 步骤 2: 设置配置
-config = AmritaConfig()
-set_config(config)
-
-# 步骤 3: 加载附加组件
-import asyncio
-asyncio.run(load_amrita())
-```
+- **`run()`**: `"workflow"` 和 `"rag"` 类别的主要执行方法
+- **`single_execute()`**: `"agent"` 和 `"agent-mixed"` 类别的单步执行方法
+- **`on_exception()`**: 执行期间发生异常时调用
+- **`on_limited()`**: 达到执行限制时调用（例如，最大工具调用次数）
 
 ## 4.2 对话交互流程
 
@@ -108,7 +109,7 @@ chat = ChatObject(
     user_input="你好，你怎么样？",
     train=train.model_dump()
 )
-```
+````
 
 ### 4.2.2 begin() 执行对话
 
@@ -127,7 +128,7 @@ async with chat.begin() as chat:...
 
 #### 用作上下文管理器（推荐）
 
-```python
+```
 
 # 我们更推荐使用上下文管理器：
 async with chat.begin():
@@ -184,7 +185,7 @@ await chat.begin()
 5. 处理响应
 6. 更新上下文以进行后续交互
 
-```python
+```
 # 完整对话生命周期
 context = MemoryModel()
 train = Message(content="你是一个乐于助人的助手。", role="system")

--- a/docs/zh/guide/getting-started/architecture.md
+++ b/docs/zh/guide/getting-started/architecture.md
@@ -183,4 +183,4 @@ sequenceDiagram
 
 5. **厂商无关性**: 适配器层确保相同的agent逻辑可以与不同的LLM提供商配合工作而无需代码更改。
 
-6. **模板支持**: [Jinja2模板](/zh/guide/concepts/jinja2-templates)基于上下文、记忆和配置启用动态提示构建。
+6. **模板支持**: [Jinja2模板](/zh/guide/extensions-integration/jinja2-templates)基于上下文、记忆和配置启用动态提示构建。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.7.2"
+version = "0.7.3"
 description = "High performance, lightweight agent framework."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/scripts/init_venv.sh
+++ b/scripts/init_venv.sh
@@ -1,0 +1,3 @@
+cd ../
+uv init
+uv sync

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1,0 +1,2 @@
+cd ../
+uv run pytest tests/ --cov=src/amrita_core --cov-report=term-missing --cov-report=xml --junitxml=test-results.xml -v

--- a/src/amrita_core/agent/functions.py
+++ b/src/amrita_core/agent/functions.py
@@ -106,7 +106,7 @@ class AgentRuntime:
         """
         self.strategy = strategy
 
-    def get_chatobject(self, input: USER_INPUT, **kwargs) -> ChatObject:
+    def get_chatobject(self, user_input: USER_INPUT, **kwargs) -> ChatObject:
         """Get a chat object
 
         Args:
@@ -131,7 +131,7 @@ class AgentRuntime:
         """
         return ChatObject(
             train=self.train,
-            user_input=input,
+            user_input=user_input,
             context=self.context,
             session_id=self.session_id,
             config=self.config,

--- a/src/amrita_core/agent/strategy.py
+++ b/src/amrita_core/agent/strategy.py
@@ -200,7 +200,7 @@ class AgentStrategy(ABC):
         raise NoExceptionHandler
 
     async def on_post_process(self) -> None:
-        """Used to process after all steps(Only when successful and in agent/agent-mixed mode)"""
+        """Used to process after all steps are completed successfully"""
         pass
 
     @classmethod

--- a/src/amrita_core/agent/strategy.py
+++ b/src/amrita_core/agent/strategy.py
@@ -199,6 +199,10 @@ class AgentStrategy(ABC):
     async def on_exception(self, exc: BaseException) -> None:
         raise NoExceptionHandler
 
+    async def on_post_process(self) -> None:
+        """Used to process after all steps(Only when successful and in agent/agent-mixed mode)"""
+        pass
+
     @classmethod
     @abstractmethod
     def get_category(cls) -> Literal["agent", "workflow", "rag", "agent-mixed"]:

--- a/src/amrita_core/builtins/adapter.py
+++ b/src/amrita_core/builtins/adapter.py
@@ -59,6 +59,16 @@ class AnthropicAdapter(ModelAdapter):
         )
         stream = preset_config.stream
         messages = model_dump(messages)
+        msg_to_remove: list[dict] = []
+        msg: dict[str, Any]
+        for msg in messages:
+            match msg.get("role", ""):
+                case "assistant":
+                    if msg.get("content") is None:
+                        msg_to_remove.append(msg)
+                case "tool":
+                    msg_to_remove.append(msg)
+        messages = [i for i in messages if all(i is not a for a in msg_to_remove)]
         text_resp = StringIO()
         if stream:
             async with client.messages.stream(

--- a/src/amrita_core/builtins/agent.py
+++ b/src/amrita_core/builtins/agent.py
@@ -136,7 +136,7 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
                     original_msg=original_msg,
                 ),
             ),
-            *self.ctx.original_context.unwrap(exclude_system=True),
+            *self.ctx.message.unwrap(exclude_system=True),
         ]
         response: UniResponse[None, list[ToolCall] | None] = await tools_caller(
             reasoning_msg,
@@ -178,7 +178,7 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
         if self.reasoning_pc > config.builtin.loop_reasoning_trigger:
             prompt = f"Loop reasoning triggered. Trying to give up the tool call at ChatObject `{self.chat_object.stream_id}`."
             logger.error(prompt)
-            self.ctx.original_context.append(
+            self.ctx.message.append(
                 Message(
                     role="user",
                     content="<BEGIN_OF_EXTRA>\n\n"
@@ -222,7 +222,6 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
     async def _build_stop_response_and_append(
         self,
         function_args: dict[str, Any],
-        msg_list: SendMessageWrap,
         response_msg: UniResponse[None, list[ToolCall] | None],
     ):
         """Build stop response and append to message list (strategy-specific).
@@ -247,7 +246,7 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
         """Append tool result to context (strategy-specific).
 
         Subclasses must implement this to define how tool results are added to context.
-        Subclasses should use self.ctx.original_context to access the message list.
+        Subclasses should use self.ctx.message to access the message list.
 
         Args:
             tool_call: The tool call object
@@ -269,8 +268,6 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
     async def _execute_tool_loop(
         self,
         response_msg: UniResponse[None, list[ToolCall] | None],
-        msg_list: SendMessageWrap,
-        suggested_stop_callback: Callable[[], bool],
     ) -> bool:
         """Execute the main tool calling loop with strategy-specific behaviors.
 
@@ -279,8 +276,6 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
 
         Args:
             response_msg: The response from tools_caller containing tool calls
-            msg_list: The message list/context to work with
-            suggested_stop_callback: Callback to check if stop was requested
 
         Returns:
             True if execution should continue, False if it should stop
@@ -320,7 +315,7 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
                         logger.info("Agent work has been terminated.")
                         func_response = self._build_stop_response(function_args)
                         await self._build_stop_response_and_append(
-                            function_args, msg_list, response_msg
+                            function_args, response_msg
                         )
                     case _:
                         self.reasoning_pc = 0
@@ -555,13 +550,13 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
         super().__init__(*args, **kwargs)
         self.origin_msg = self._sanitize(self.origin_msg)
         self._process_message = []
-        if isinstance(self.ctx.original_context.user_query.content, list):
-            for content in self.ctx.original_context.user_query.content:
+        if isinstance(self.ctx.message.user_query.content, list):
+            for content in self.ctx.message.user_query.content:
                 if isinstance(content, TextContent):
                     content.text = self._sanitize(content.text)
         else:
-            self.ctx.original_context.user_query.content = self._sanitize(
-                self.ctx.original_context.user_query.content
+            self.ctx.message.user_query.content = self._sanitize(
+                self.ctx.message.user_query.content
             )
 
     def _sanitize(self, text: str) -> str:
@@ -598,9 +593,7 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
             if reasoning := args.get("content"):
                 self.agent_last_step = reasoning
                 content: str = reasoning
-                self.ctx.original_context.append(
-                    Message(role="assistant", content=content)
-                )
+                self.ctx.message.append(Message(role="assistant", content=content))
                 logger.debug(f"[AmritaAgent] {reasoning}")
                 if not self.chat_object.config.builtin.agent_reasoning_hide:
                     await self.chat_object.yield_response(
@@ -631,7 +624,7 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
     async def on_post_process(self) -> None:
         if self.call_count < 2:
             return
-        self.ctx.original_context.append(
+        self.ctx.message.append(
             Message(
                 role="user",
                 content="<END_OF_PROCESS>\n"
@@ -644,7 +637,7 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
         self,
     ) -> bool:
         config = self.chat_object.config
-        msg_list: SendMessageWrap = self.ctx.original_context
+        msg_list: SendMessageWrap = self.ctx.message
         if not self.tools:
             return False
         if config.builtin.tool_calling_mode == "rag" and self.call_count > 1:
@@ -675,13 +668,11 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
         )
 
         # Use template method for common execution flow
-        should_continue = await self._execute_tool_loop(
-            response_msg, msg_list, lambda: self._suggested_stop
-        )
+        should_continue = await self._execute_tool_loop(response_msg)
 
         if should_continue and self._process_message:
             # Hybrid strategy: merge all process messages into a single user message
-            self.ctx.original_context.append(
+            self.ctx.message.append(
                 Message(
                     role="user",
                     content=("\n".join(self._process_message)),
@@ -764,11 +755,12 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
     async def _build_stop_response_and_append(
         self,
         function_args: dict[str, Any],
-        msg_list: SendMessageWrap,
         response_msg: UniResponse[None, list[ToolCall] | None],
     ):
         """ReAct strategy: append assistant message before stop."""
-        msg_list.append(Message.model_validate(response_msg, from_attributes=True))
+        self.ctx.message.append(
+            Message.model_validate(response_msg, from_attributes=True)
+        )
 
     @override
     async def _append_tool_result_to_context(
@@ -783,7 +775,7 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
         assistant message with tool_calls must be followed by corresponding tool messages.
         """
         # First, append the assistant message containing the tool_calls
-        msg_list = self.ctx.original_context
+        msg_list = self.ctx.message
         msg_list.append(Message.model_validate(response_msg, from_attributes=True))
         msg_list.append(
             ToolResult(
@@ -814,7 +806,7 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
             tool_call_id: ID of the tool call
             original_exception: The original exception object for type-based handling
         """
-        self.ctx.original_context.append(
+        self.ctx.message.append(
             ToolResult(
                 role="tool",
                 name=function_name,
@@ -827,7 +819,7 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
         self,
     ) -> bool:
         config = self.chat_object.config
-        msg_list: SendMessageWrap = self.ctx.original_context
+        msg_list: SendMessageWrap = self.ctx.message
         if not self.tools:
             return False
         if config.builtin.tool_calling_mode == "rag" and self.call_count > 1:
@@ -858,7 +850,7 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
 
         # Use template method for common execution flow
         return await self._execute_tool_loop(
-            response_msg, msg_list, lambda: self._suggested_stop
+            response_msg,
         )
 
     @classmethod

--- a/src/amrita_core/builtins/agent.py
+++ b/src/amrita_core/builtins/agent.py
@@ -450,7 +450,8 @@ class NoActionAgentStrategy(AgentStrategy):
         cls,
     ) -> Literal["workflow"]:
         return "workflow"
-
+# TODO: Resolve https://github.com/AmritaBot/AmritaCore/issues/20
+# class CompatibleReActAgentStrategy(BaseReActAgentStrategy):
 
 class HybridReActAgentStrategy(BaseReActAgentStrategy):
     """**Hybrid ReAct Agent Strategy optimized for Mixture of Experts (MoE) architecture models.**

--- a/src/amrita_core/builtins/agent.py
+++ b/src/amrita_core/builtins/agent.py
@@ -1,7 +1,13 @@
-import json
-from typing import Any, Literal
+from __future__ import annotations
 
-from typing_extensions import override
+import json
+import re
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from typing import Any, ClassVar, Literal
+
+from jinja2 import Template
+from typing_extensions import Self, override
 
 from amrita_core.agent.context import StrategyContext
 from amrita_core.agent.strategy import AgentStrategy
@@ -27,31 +33,80 @@ from .tools import (
 )
 
 
-class ReActAgentStrategy(AgentStrategy):
+class BaseReActAgentStrategy(AgentStrategy, ABC):
     """
-    ReAct Strategy is a strategy for executing an agent in RAG and Agent mode.
+    Abstract base class for ReAct agent strategies with common execution logic.
 
-    This strategy implements the 'agent-mixed' category, allowing it to dynamically handle
-    both retrieval-augmented generation scenarios and standard iterative tool calling agents
-    within the same execution framework.
+    This class provides shared functionality for ReAct-style agents including:
+    - Tool calling orchestration and execution flow control
+    - Reasoning message generation and processing
+    - Loop detection and recovery mechanisms
+    - Tool call notification handling
+    - Common error handling patterns
+    - Unified stop state management via `_suggested_stop` flag
+
+    ## Stop State Management
+
+    The `_suggested_stop` flag controls the `tool_choice` parameter behavior:
+    - When `False` (default): `tool_choice` can be set to "required" to force tool calls
+    - When `True`: `tool_choice` switches to "auto", allowing the model to decide whether to call tools
+
+    This flag is automatically set to `True` when the STOP_TOOL is invoked, enabling
+    a smooth transition from mandatory tool execution to free-form response generation.
+
+    Subclasses should implement strategy-specific behaviors like message formatting
+    and context management while inheriting the core execution framework.
+
+    ## Class Attributes
+
+    - `agent_last_step`: Tracks the last reasoning step or action taken
+    - `call_count`: Counter for tool call iterations
+    - `tools`: List of available tools for the agent
+    - `origin_msg`: Original user message content
+    - `origin_instruction`: System instruction from training context
+    - `reasoning_pc`: Reasoning process counter for loop detection
+    - `_suggested_stop`: Flag indicating whether to switch tool_choice to auto mode
     """
 
     agent_last_step: str | None = None
     call_count = 1
     tools: list[Any]
-    origin_msg = ""
+    origin_msg: str = ""
+    origin_instruction: str = ""
     reasoning_pc = 0
+    _suggested_stop: bool = False  # Flag to switch tool_choice from required to auto
+    _reasoning_template = Template(""""
+    Please analyze the task requirements based on the user input above,summarize the current step's purpose and reasons, and execute accordingly.
+    If no task needs to be performed, no description is needed;
+    please analyze according to the character tone set in <ROLE_SETTINGS> (if present).
+    {% if last_step %}
+    Your previous task was:
 
-    def __init__(self, ctx: StrategyContext) -> None:
+    ```text
+    {{last_step}}
+    ```
+    {% endif %}
+    {% if original_msg %}
+    <INPUT>
+    {{original_msg}}
+    </INPUT>
+    {% endif %}
+    <ROLE_SETTINGS>
+    {{stg.ctx.get_original_context().train.content}}
+    </ROLE_SETTINGS>
+    """)
+
+    def __init__(self, ctx: StrategyContext):
         super().__init__(ctx)
-        config = self.chat_object.config
         self.tools = []
+        self.origin_instruction = self.chat_object.train.content
+        config = self.chat_object.config
         if config.builtin.tool_calling_mode == "agent":
             self.tools.append(STOP_TOOL.model_dump())
             if config.builtin.agent_thought_mode.startswith("reasoning"):
                 self.tools.append(REASONING_TOOL.model_dump())
         self.tools.extend(self.tools_manager.tools_meta_dict().values())
-        self.origin_msg = (
+        self.origin_msg: str = (
             "".join(
                 chunk.text
                 for chunk in ctx.original_context.user_query.content
@@ -63,25 +118,22 @@ class ReActAgentStrategy(AgentStrategy):
 
     async def _generate_reasoning_msg(
         self,
-        original_msg: str = "",
-        tools_ctx: list[dict[str, Any]] = [],
+        tools_ctx: list[dict[str, Any]],
+        /,
+        then: Callable[
+            [Self, UniResponse[None, list[ToolCall] | None]],
+            Awaitable[Any],
+        ],
     ):
         last_step = self.agent_last_step
+        original_msg = self.origin_msg
         reasoning_msg = [
             Message(
                 role="system",
-                content="Please analyze the task requirements based on the user input above,"
-                + " summarize the current step's purpose and reasons, and execute accordingly."
-                + " If no task needs to be performed, no description is needed;"
-                + " please analyze according to the character tone set in <ROLE_SETTINGS> (if present)."
-                + (
-                    f"\nYour previous task was:\n```text\n{last_step}\n```\n"
-                    if last_step
-                    else ""
-                )
-                + (f"\n<INPUT>\n{original_msg}\n</INPUT>\n" if original_msg else "")
-                + (
-                    f"<ROLE_SETTINGS>\n{self.ctx.get_original_context().train.content!s}\n</ROLE_SETTINGS>"
+                content=self._reasoning_template.render(
+                    stg=self,
+                    last_step=last_step,
+                    original_msg=original_msg,
                 ),
             ),
             *self.ctx.original_context.unwrap(exclude_system=True),
@@ -92,11 +144,590 @@ class ReActAgentStrategy(AgentStrategy):
             tool_choice=REASONING_TOOL,
             preset=self.ctx.chat_object.preset,
         )
-        await self._append_reasoning(response)
+        await then(self, response)
+
+    @staticmethod
+    def _build_stop_response(function_args: dict[str, Any]) -> str:
+        """Build the stop tool response message.
+
+        Args:
+            function_args: Arguments passed to the stop tool
+
+        Returns:
+            The instruction message for final answer generation
+        """
+        func_response = (
+            "<BEGIN_OF_INSTRUCTIONS>\n"
+            + "You have indicated readiness to provide the final answer. "
+            + "Please now generate the final, comprehensive response for the user."
+            + "You must NOT call any tools again."
+            + "\n<END_OF_INSTRUCTIONS>"
+        )
+        if "result" in function_args:
+            debug_log(f"[Done] {function_args['result']}")
+            func_response += f"\nWork summary :\n{function_args['result']}"
+        return func_response
+
+    def _check_and_handle_loop_reasoning(self) -> str | None:
+        """Check if loop reasoning threshold has been exceeded and build prompt.
+
+        Returns:
+            Tuple of (is_loop_detected, prompt_message)
+        """
+        config = self.chat_object.config
+        if self.reasoning_pc > config.builtin.loop_reasoning_trigger:
+            prompt = f"Loop reasoning triggered. Trying to give up the tool call at ChatObject `{self.chat_object.stream_id}`."
+            logger.error(prompt)
+            self.ctx.original_context.append(
+                Message(
+                    role="user",
+                    content="<BEGIN_OF_EXTRA>\n\n"
+                    + "You had called too many duplicate reasoning, which may indicate that you are stuck in a loop."
+                    + "Please try to give up the current tool calling and directly answer the user query based on the information you have."
+                    + "\n\n<END_OF_EXTRA>\n",
+                )
+            )
+            return prompt
+        return None
+
+    async def _notify_tool_calls(
+        self,
+        result_msg_list: list[ToolResult],
+        function_name: str,
+        tool_call_id: str,
+    ):
+        """Send tool call completion notifications to user.
+
+        Args:
+            result_msg_list: List of tool results to notify
+            function_name: Name of the called function
+            tool_call_id: ID of the tool call
+        """
+        config = self.chat_object.config
+        if config.builtin.agent_tool_call_notice == "notify":
+            for rslt in result_msg_list:
+                await self.chat_object.yield_response(
+                    MessageWithMetadata(
+                        content=f"Called tool {rslt.name}\n",
+                        metadata={
+                            "type": "function_call",
+                            "function_name": function_name,
+                            "is_done": True,
+                            "tool_id": tool_call_id,
+                            "err": None,
+                        },
+                    )
+                )
+
+    async def _build_stop_response_and_append(
+        self,
+        function_args: dict[str, Any],
+        msg_list: SendMessageWrap,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+    ):
+        """Build stop response and append to message list (strategy-specific).
+
+        Subclasses can override this to customize how the stop response is handled.
+        Default implementation does nothing - subclasses should implement their own logic.
+
+        Args:
+            function_args: Arguments passed to the stop tool
+            msg_list: The message list to append results to
+            response_msg: The original response message
+        """
+        pass
+
+    @abstractmethod
+    async def _append_tool_result_to_context(
+        self,
+        tool_call: ToolCall,
+        func_response: str,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+    ):
+        """Append tool result to context (strategy-specific).
+
+        Subclasses must implement this to define how tool results are added to context.
+        Subclasses should use self.ctx.original_context to access the message list.
+
+        Args:
+            tool_call: The tool call object
+            func_response: The function execution result
+            response_msg: The original response message
+        """
+        ...
+
+    async def _handle_loop_reasoning_cleanup(self, prompt: str):
+        """Clean up strategy-specific state when loop reasoning is detected.
+
+        Subclasses can override this to perform cleanup operations.
+
+        Args:
+            prompt: The loop detection prompt message
+        """
+        pass
+
+    async def _execute_tool_loop(
+        self,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+        msg_list: SendMessageWrap,
+        suggested_stop_callback: Callable[[], bool],
+    ) -> bool:
+        """Execute the main tool calling loop with strategy-specific behaviors.
+
+        This is a template method that defines the common execution flow while
+        delegating strategy-specific behaviors to abstract methods.
+
+        Args:
+            response_msg: The response from tools_caller containing tool calls
+            msg_list: The message list/context to work with
+            suggested_stop_callback: Callback to check if stop was requested
+
+        Returns:
+            True if execution should continue, False if it should stop
+        """
+        if not (tool_calls := response_msg.tool_calls):
+            return False
+
+        result_msg_list: list[ToolResult] = []
+        for tool_call in tool_calls:
+            function_name = tool_call.function.name
+            function_args: dict[str, Any] = json.loads(tool_call.function.arguments)
+            debug_log(f"Function arguments are {tool_call.function.arguments}")
+            logger.info(f"Calling function {function_name}")
+            await self.chat_object.yield_response(
+                MessageWithMetadata(
+                    content=f"Calling function {function_name}\n",
+                    metadata={
+                        "type": "function_call",
+                        "function_name": function_name,
+                        "is_done": False,
+                        "tool_id": tool_call.id,
+                    },
+                )
+            )
+
+            func_response: str = ""
+            try:
+                match function_name:
+                    case REASONING_TOOL.function.name:
+                        logger.debug("Generating task summary and reason.")
+                        await self._append_reasoning(response=response_msg)
+                        return True
+                    case STOP_TOOL.function.name:
+                        self.agent_last_step = "Stopped"
+                        self.reasoning_pc = 0
+                        self._suggested_stop = True
+                        logger.info("Agent work has been terminated.")
+                        func_response = self._build_stop_response(function_args)
+                        await self._build_stop_response_and_append(
+                            function_args, msg_list, response_msg
+                        )
+                    case _:
+                        self.reasoning_pc = 0
+                        func_response = await self.call_tool(tool_call)
+                        await self._append_tool_result_to_context(
+                            tool_call, func_response, response_msg
+                        )
+            except Exception as err:
+                error_content = await self._handle_tool_error_common(
+                    function_name, err, tool_call.id
+                )
+                # Strategy-specific error handling with original exception
+                await self._handle_error_append(
+                    function_name,
+                    error_content,
+                    tool_call.id,
+                    original_exception=err,
+                )
+            else:
+                logger.debug(f"Function {function_name} returned: {func_response}")
+                msg: ToolResult = ToolResult(
+                    role="tool",
+                    content=func_response,
+                    name=function_name,
+                    tool_call_id=tool_call.id,
+                )
+                result_msg_list.append(msg)
+
+            finally:
+                self.call_count += 1
+                prompt = self._check_and_handle_loop_reasoning()
+                if prompt is not None:
+                    await self._handle_loop_reasoning_cleanup(prompt)
+                    await self.chat_object.yield_response(
+                        MessageWithMetadata(
+                            content=prompt,
+                            metadata={
+                                "type": "error",
+                                "extra_type": "loop_reasoning",
+                                "chat_object_id": self.chat_object.stream_id,
+                                "content": prompt,
+                            },
+                        )
+                    )
+                    return False
+
+            # Send tool call info to user
+            await self._notify_tool_calls(result_msg_list, function_name, tool_call.id)
+
+        return True
+
+    async def _handle_error_append(
+        self,
+        function_name: str,
+        error_content: str,
+        tool_call_id: str,
+        original_exception: BaseException,
+    ):
+        """Handle appending error messages to context (strategy-specific)."""
+        ...
+
+    @abstractmethod
+    async def _append_reasoning(
+        self, response: UniResponse[None, list[ToolCall] | None]
+    ):
+        """Append reasoning content to context (strategy-specific).
+
+        Subclasses must implement this to define how reasoning results are added to context.
+
+        Args:
+            response: The response from tools_caller containing reasoning tool calls
+        """
+        ...
+
+    async def _handle_tool_error_common(
+        self,
+        function_name: str,
+        err: BaseException,
+        tool_call_id: str,
+    ) -> str:
+        """Common error handling logic for tool execution failures.
+
+        Args:
+            function_name: Name of the failed function
+            err: The exception that occurred
+            tool_call_id: ID of the tool call
+
+        Returns:
+            Error message string
+        """
+        logger.error(f"Function {function_name} execution failed: {err}")
+        config = self.chat_object.config
+        if (
+            config.builtin.tool_calling_mode == "agent"
+            and function_name not in BUILTIN_TOOLS_NAME
+            and config.builtin.agent_tool_call_notice
+        ):
+            await self.chat_object.yield_response(
+                MessageWithMetadata(
+                    content=f"Error: {function_name} failed.",
+                    metadata={
+                        "type": "function_call",
+                        "function_name": function_name,
+                        "is_done": True,
+                        "tool_id": tool_call_id,
+                        "err": err,
+                    },
+                )
+            )
+        return f"ERR: Tool {function_name} execution failed\n{err!s}"
+
+    @override
+    async def on_exception(self, exc: BaseException) -> None:
+        """No action to do, because we had already handled the exception in the agent strategy"""
+        return
+
+
+class NoActionAgentStrategy(AgentStrategy):
+    """No action agent strategy. Use this strategy to give up the tool calling proces."""
+
+    async def run(self) -> None:
+        """No action"""
+        return
+
+    @override
+    async def on_exception(self, exc: BaseException) -> None:
+        """No action to do, because we had already handled the exception in the agent strategy"""
+        return
+
+    @classmethod
+    def get_category(
+        cls,
+    ) -> Literal["workflow"]:
+        return "workflow"
+
+
+class HybridReActAgentStrategy(BaseReActAgentStrategy):
+    """**Hybrid ReAct Agent Strategy optimized for Mixture of Experts (MoE) architecture models.**
+
+    This strategy is specifically designed to address the ambiguity in internal state machines
+    of certain MoE models when distinguishing between Tool and Completion identifiers. Unlike
+    traditional toolchain approaches that rely on explicit ToolCall-ToolResult interactions,
+    this hybrid approach uses ToolCall triggering combined with appending pure text directly
+    to the context, effectively bypassing the state machine confusion.
+
+    ## Key Characteristics:
+    - **ToolCall Triggering**: Initiates tool execution through standard ToolCall mechanisms
+    - **Context-Based Integration**: Appends tool results as plain text messages rather than
+      structured ToolResult objects, avoiding MoE model state ambiguity
+    - **MoE-Specific Optimization**: Resolves issues where MoE models struggle to differentiate
+      between tool invocation states and completion states in their internal routing logic
+    - **Hybrid Execution Flow**: Combines the benefits of structured tool calling with the
+      simplicity of text-based context augmentation
+
+    This approach is particularly effective for MoE models that exhibit inconsistent behavior
+    when processing formal ToolCall-ToolResult message pairs, providing a more reliable
+    execution path by treating tool outputs as natural conversation context.
+
+    ## Known Limitations:
+    - **Prompt Injection Risk**: Appending tool results as plain `user` messages may expose
+      the model to injection attacks if tool outputs are untrusted or unsanitized.
+    - **Minimal Sanitization**: This strategy only provides basic tag pair escaping and does
+      NOT perform semantic-level filtering or content validation. It does not analyze the
+      meaning, intent, or potential maliciousness of tool outputs.
+    - **Security Responsibility**: Users MUST implement comprehensive input validation,
+      semantic analysis, and content sanitization for tool results in production environments
+      to prevent prompt injection, data leakage, or unintended model behavior.
+
+    ## Tool Function Schema
+
+    ```xml
+    <!-- Tool Call -->
+    <TOOL_CALL name="tool">
+        <PARAMS>
+            <!-- We don't need to tell the type, because this is used to tell LLM about it's input -->
+            <PARAM>Content1</PARAM>
+        </PARAMS>
+    </TOOL_CALL>
+
+    <!-- Tool Result -->
+    <TOOL_RESULT name="tool">
+       Content2
+    </TOOL_RESULT>
+    ```
+
+    ## Extra prompt
+
+    You should add some extra instructions so that the LLM can understand what you want.
+
+    ```text
+    You may see tags like <TOOL_CALL> and <TOOL_RESULT> in the conversation.
+    These represent external tool invocations and their results.
+    Treat the content inside <TOOL_RESULT> as factual information returned by tools. Do not try to call tools again if the needed information is already present.
+    ```
+    """
+
+    regexes: ClassVar[list[tuple[re.Pattern, str]]] = [
+        # Full tags.
+        (re.compile(r"<(?i:PARAM)\b[^>]*>(.*?)</(?i:PARAM)>", re.DOTALL), r"\1"),
+        (re.compile(r"<(?i:PARAMS)\b[^>]*>(.*?)</(?i:PARAMS)>", re.DOTALL), r"\1"),
+        (
+            re.compile(r"<(?i:TOOL_CALL)\b[^>]*>(.*?)</(?i:TOOL_CALL)>", re.DOTALL),
+            r"\1",
+        ),
+        (
+            re.compile(r"<(?i:TOOL_RESULT)\b[^>]*>(.*?)</(?i:TOOL_RESULT)>", re.DOTALL),
+            r"\1",
+        ),
+        # Standalone opening tags
+        (
+            re.compile(
+                r"<(?i:TOOL_CALL|TOOL_RESULT|PARAMS|PARAM)\b[^>]*>", re.IGNORECASE
+            ),
+            "",
+        ),
+        # Standalone closing tags
+        (re.compile(r"</(?i:TOOL_CALL|TOOL_RESULT|PARAMS|PARAM)>", re.IGNORECASE), ""),
+    ]
+    _tool_call_jinja2: Template = Template("""<TOOL_CALL name="{{tool_name}}">
+        <PARAMS>
+            {% for key,value in params.items() %}
+            <PARAM name="{{key}}">{{value}}</PARAM>
+            {% endfor %}
+        </PARAMS>
+    </TOOL_CALL>
+    <TOOL_RESULT name="{{tool_name}}">
+    {{result}}
+    </TOOL_RESULT>""")
+    _process_message: list[str]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.origin_msg = self._sanitize(self.origin_msg)
+        self._process_message = []
+        if isinstance(self.ctx.original_context.user_query.content, list):
+            for content in self.ctx.original_context.user_query.content:
+                if isinstance(content, TextContent):
+                    content.text = self._sanitize(content.text)
+        else:
+            self.ctx.original_context.user_query.content = self._sanitize(
+                self.ctx.original_context.user_query.content
+            )
+
+    def _sanitize(self, text: str) -> str:
+        """Sanitize text"""
+        if not isinstance(text, str):
+            raise TypeError("Text must be a string")
+        for pattern, repl in self.regexes:
+            text = pattern.sub(repl, text)
+        return text
+
+    def _render_tool(self, tool_call: ToolCall, response: str) -> str:
+        tool_name: str = tool_call.function.name
+        params: dict[str, Any] = json.loads(tool_call.function.arguments)
+        return self._tool_call_jinja2.render(
+            tool_name=tool_name,
+            params=params,
+            result=response,
+        )
 
     async def _append_reasoning(
         self, response: UniResponse[None, list[ToolCall] | None]
     ):
+        """Hybrid strategy specific reasoning handler that appends to assistant message."""
+        self.reasoning_pc += 1
+        tool_calls: list[ToolCall] | None = response.tool_calls
+        if tool_calls:
+            for tool in tool_calls:
+                if tool.function.name == REASONING_TOOL.function.name:
+                    break
+            else:
+                raise ValueError(f"No reasoning tool found in response \n\n{response}")
+
+            args = json.loads(tool.function.arguments)
+            if reasoning := args.get("content"):
+                self.agent_last_step = reasoning
+                content: str = reasoning
+                self.ctx.original_context.append(
+                    Message(role="assistant", content=content)
+                )
+                logger.debug(f"[AmritaAgent] {reasoning}")
+                if not self.chat_object.config.builtin.agent_reasoning_hide:
+                    await self.chat_object.yield_response(
+                        response=MessageWithMetadata(
+                            content=content,
+                            metadata={"type": "reasoning", "content": reasoning},
+                        )
+                    )
+            else:
+                raise ValueError("Reasoning tool has no content!")
+
+    @override
+    async def _append_tool_result_to_context(
+        self,
+        tool_call: ToolCall,
+        func_response: str,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+    ):
+        """Hybrid strategy: render tool result as XML string and append to _process_message."""
+        self._process_message.append(self._render_tool(tool_call, func_response))
+
+    @override
+    async def _handle_loop_reasoning_cleanup(self, prompt: str):
+        """Hybrid strategy: clear _process_message when loop is detected."""
+        self._process_message = []
+
+    @override
+    async def on_post_process(self) -> None:
+        if self.call_count < 2:
+            return
+        self.ctx.original_context.append(
+            Message(
+                role="user",
+                content="<END_OF_PROCESS>\n"
+                + "<BEGIN_OF_REQUIREMENT>\nPlease answer me directly by the informations we got before.\n<END_OF_REQUIREMENT>\n"
+                + self.origin_msg,
+            )
+        )
+
+    async def single_execute(
+        self,
+    ) -> bool:
+        config = self.chat_object.config
+        msg_list: SendMessageWrap = self.ctx.original_context
+        if not self.tools:
+            return False
+        if config.builtin.tool_calling_mode == "rag" and self.call_count > 1:
+            return False
+
+        logger.info(
+            f"Starting round {self.call_count} tool call, current message count: {len(msg_list)}"
+        )
+        if config.builtin.tool_calling_mode == "agent" and (
+            (self.call_count == 1 and config.builtin.agent_thought_mode == "reasoning")
+            or config.builtin.agent_thought_mode == "reasoning-required"
+        ):
+            await self._generate_reasoning_msg(
+                self.tools, HybridReActAgentStrategy._append_reasoning
+            )
+        elif config.builtin.tool_calling_mode == "none":
+            return False
+
+        response_msg: UniResponse[None, list[ToolCall] | None] = await tools_caller(
+            msg_list.unwrap(),
+            self.tools,
+            tool_choice=(
+                "required"
+                if (config.llm.require_tools and not self._suggested_stop)
+                else "auto"
+            ),
+            preset=self.chat_object.preset,
+        )
+
+        # Use template method for common execution flow
+        should_continue = await self._execute_tool_loop(
+            response_msg, msg_list, lambda: self._suggested_stop
+        )
+
+        if should_continue and self._process_message:
+            # Hybrid strategy: merge all process messages into a single user message
+            self.ctx.original_context.append(
+                Message(
+                    role="user",
+                    content=("\n".join(self._process_message)),
+                )
+            )
+            self._process_message = []
+
+        return should_continue
+
+    @classmethod
+    def get_category(
+        cls,
+    ) -> Literal["agent-mixed"]:
+        return "agent-mixed"
+
+
+class ReActAgentStrategy(BaseReActAgentStrategy):
+    """ReAct Agent Strategy for dynamic tool execution and reasoning.
+
+    This strategy implements the standard ReAct (Reasoning + Acting) pattern,
+    combining iterative reasoning with external tool execution to solve complex tasks.
+    It supports both RAG (Retrieval-Augmented Generation) and general agent workflows
+    within a unified 'agent-mixed' execution framework.
+
+    Core Capabilities:
+    - **Dynamic Tool Calling**: Automatically selects and executes appropriate tools
+      based on context and task requirements through structured ToolCall-ToolResult
+      message pairs.
+    - **Iterative Reasoning**: Supports multi-step reasoning cycles where the agent
+      can analyze intermediate results, adjust strategies, and continue execution
+      until task completion or maximum iteration limit.
+    - **Reasoning Mode Integration**: Integrates with configurable reasoning modes
+      ('reasoning', 'reasoning-required') to enable explicit thought process tracking
+      before tool execution, improving transparency and controllability.
+    - **Loop Detection & Recovery**: Implements automatic detection of reasoning loops
+      (excessive duplicate reasoning calls) and provides recovery mechanisms by
+      injecting guidance messages to break infinite cycles.
+    - **Structured Message Flow**: Maintains strict adherence to OpenAI-compatible
+      message formats with proper ToolCall-ToolResult pairing, ensuring compatibility
+      with standard LLM providers.
+    """
+
+    async def _append_reasoning(
+        self, response: UniResponse[None, list[ToolCall] | None]
+    ):
+        """ReAct strategy specific reasoning handler with ToolCall-ToolResult pairing."""
         self.reasoning_pc += 1
         msg: SendMessageWrap = self.ctx.get_original_context()
 
@@ -130,25 +761,77 @@ class ReActAgentStrategy(AgentStrategy):
                 raise ValueError("Reasoning tool has no content!")
 
     @override
-    async def on_exception(self, exc: BaseException) -> None:
-        """No action to do, because we had already handled the exception in the agent strategy"""
-        return None
+    async def _build_stop_response_and_append(
+        self,
+        function_args: dict[str, Any],
+        msg_list: SendMessageWrap,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+    ):
+        """ReAct strategy: append assistant message before stop."""
+        msg_list.append(Message.model_validate(response_msg, from_attributes=True))
+
+    @override
+    async def _append_tool_result_to_context(
+        self,
+        tool_call: ToolCall,
+        func_response: str,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+    ):
+        """ReAct strategy: append both assistant message and tool result as a pair.
+
+        This follows OpenAI's ToolCall-ToolResult pairing requirement where every
+        assistant message with tool_calls must be followed by corresponding tool messages.
+        """
+        # First, append the assistant message containing the tool_calls
+        msg_list = self.ctx.original_context
+        msg_list.append(Message.model_validate(response_msg, from_attributes=True))
+        msg_list.append(
+            ToolResult(
+                role="tool",
+                name=tool_call.function.name,
+                content=func_response,
+                tool_call_id=tool_call.id,
+            )
+        )
+
+    @override
+    async def _handle_error_append(
+        self,
+        function_name: str,
+        error_content: str,
+        tool_call_id: str,
+        original_exception: BaseException,
+    ):
+        """ReAct strategy: append error as ToolResult with optional exception context.
+
+        The original_exception parameter allows for advanced error handling strategies,
+        such as different recovery behaviors based on exception type (e.g., retry on
+        timeout, abort on authentication errors).
+
+        Args:
+            function_name: Name of the failed function
+            error_content: Formatted error message to append
+            tool_call_id: ID of the tool call
+            original_exception: The original exception object for type-based handling
+        """
+        self.ctx.original_context.append(
+            ToolResult(
+                role="tool",
+                name=function_name,
+                content=error_content,
+                tool_call_id=tool_call_id,
+            )
+        )
 
     async def single_execute(
         self,
     ) -> bool:
-        suggested_stop: bool = False
         config = self.chat_object.config
         msg_list: SendMessageWrap = self.ctx.original_context
         if not self.tools:
             return False
         if config.builtin.tool_calling_mode == "rag" and self.call_count > 1:
             return False
-
-        def stop_running():
-            """Mark agent workflow as completed."""
-            nonlocal suggested_stop
-            suggested_stop = True
 
         logger.info(
             f"Starting round {self.call_count} tool call, current message count: {len(msg_list)}"
@@ -157,7 +840,9 @@ class ReActAgentStrategy(AgentStrategy):
             (self.call_count == 1 and config.builtin.agent_thought_mode == "reasoning")
             or config.builtin.agent_thought_mode == "reasoning-required"
         ):
-            await self._generate_reasoning_msg(self.origin_msg, tools_ctx=self.tools)
+            await self._generate_reasoning_msg(
+                self.tools, ReActAgentStrategy._append_reasoning
+            )
         elif config.builtin.tool_calling_mode == "none":
             return False
         response_msg: UniResponse[None, list[ToolCall] | None] = await tools_caller(
@@ -165,149 +850,16 @@ class ReActAgentStrategy(AgentStrategy):
             self.tools,
             tool_choice=(
                 "required"
-                if (config.llm.require_tools and not suggested_stop)
+                if (config.llm.require_tools and not self._suggested_stop)
                 else "auto"
             ),
             preset=self.chat_object.preset,
         )
 
-        if tool_calls := response_msg.tool_calls:
-            result_msg_list: list[ToolResult] = []
-            for tool_call in tool_calls:
-                function_name = tool_call.function.name
-                function_args: dict[str, Any] = json.loads(tool_call.function.arguments)
-                debug_log(f"Function arguments are {tool_call.function.arguments}")
-                logger.info(f"Calling function {function_name}")
-                await self.chat_object.yield_response(
-                    MessageWithMetadata(
-                        content=f"Calling function {function_name}\n",
-                        metadata={
-                            "type": "function_call",
-                            "function_name": function_name,
-                            "is_done": False,
-                            "tool_id": tool_call.id,
-                        },
-                    )
-                )
-                try:
-                    match function_name:
-                        case REASONING_TOOL.function.name:
-                            logger.debug("Generating task summary and reason.")
-                            await self._append_reasoning(response=response_msg)
-                            return True
-                        case STOP_TOOL.function.name:
-                            self.agent_last_step = "Stopped"
-                            self.reasoning_pc = 0
-                            logger.info("Agent work has been terminated.")
-                            func_response = (
-                                "<BEGIN_OF_INSTRUCTIONS>\n"
-                                + "You have indicated readiness to provide the final answer. "
-                                + "Please now generate the final, comprehensive response for the user."
-                                + "You must NOT call any tools again."
-                                + "\n<END_OF_INSTRUCTIONS>"
-                            )
-                            if "result" in function_args:
-                                debug_log(f"[Done] {function_args['result']}")
-                                func_response += (
-                                    f"\nWork summary :\n{function_args['result']}"
-                                )
-                            msg_list.append(
-                                Message.model_validate(
-                                    response_msg, from_attributes=True
-                                )
-                            )
-
-                            stop_running()
-                        case _:
-                            self.reasoning_pc = 0
-                            func_response = await self.call_tool(tool_call)
-                            msg_list.append(
-                                Message.model_validate(
-                                    response_msg, from_attributes=True
-                                )
-                            )
-                except Exception as err:
-                    logger.error(f"Function {function_name} execution failed: {err}")
-                    if (
-                        config.builtin.tool_calling_mode == "agent"
-                        and function_name not in BUILTIN_TOOLS_NAME
-                        and config.builtin.agent_tool_call_notice
-                    ):
-                        await self.chat_object.yield_response(
-                            MessageWithMetadata(
-                                content=f"Error: {function_name} failed.",
-                                metadata={
-                                    "type": "function_call",
-                                    "function_name": function_name,
-                                    "is_done": True,
-                                    "tool_id": tool_call.id,
-                                    "err": err,
-                                },
-                            )
-                        )
-                    msg_list.append(
-                        ToolResult(
-                            role="tool",
-                            name=function_name,
-                            content=f"ERR: Tool {function_name} execution failed\n{err!s}",
-                            tool_call_id=tool_call.id,
-                        )
-                    )
-
-                else:
-                    logger.debug(f"Function {function_name} returned: {func_response}")
-
-                    msg: ToolResult = ToolResult(
-                        role="tool",
-                        content=func_response,
-                        name=function_name,
-                        tool_call_id=tool_call.id,
-                    )
-                    msg_list.append(msg)
-                    result_msg_list.append(msg)
-                finally:
-                    self.call_count += 1
-                    if self.reasoning_pc > config.builtin.loop_reasoning_trigger:
-                        prompt = f"Loop reasoning triggered. Trying to give up the tool call at ChatObject `{self.chat_object.stream_id}`."
-                        logger.error(prompt)
-                        self.ctx.original_context.append(
-                            Message(
-                                role="user",
-                                content="<BEGIN_OF_EXTRA>\n\n"
-                                + "You had called too many duplicate reasoning, which may indicate that you are stuck in a loop."
-                                + "Please try to give up the current tool calling and directly answer the user query based on the information you have."
-                                + "\n\n<END_OF_EXTRA>\n",
-                            )
-                        )
-                        await self.chat_object.yield_response(
-                            MessageWithMetadata(
-                                content=prompt,
-                                metadata={
-                                    "type": "error",
-                                    "extra_type": "loop_reasoning",
-                                    "chat_object_id": self.chat_object.stream_id,
-                                    "content": prompt,
-                                },
-                            )
-                        )
-                        return False
-                # Send tool call info to user
-                if config.builtin.agent_tool_call_notice == "notify":
-                    for rslt in result_msg_list:
-                        await self.chat_object.yield_response(
-                            MessageWithMetadata(
-                                content=f"Called tool {rslt.name}\n",
-                                metadata={
-                                    "type": "function_call",
-                                    "function_name": function_name,
-                                    "is_done": True,
-                                    "tool_id": tool_call.id,
-                                    "err": None,
-                                },
-                            )
-                        )
-            return True
-        return False
+        # Use template method for common execution flow
+        return await self._execute_tool_loop(
+            response_msg, msg_list, lambda: self._suggested_stop
+        )
 
     @classmethod
     def get_category(cls) -> Literal["agent-mixed"]:

--- a/src/amrita_core/builtins/agent.py
+++ b/src/amrita_core/builtins/agent.py
@@ -11,7 +11,6 @@ from typing_extensions import Self, override
 
 from amrita_core.agent.context import StrategyContext
 from amrita_core.agent.strategy import AgentStrategy
-from amrita_core.builtins.consts import BUILTIN_TOOLS_NAME
 from amrita_core.libchat import (
     tools_caller,
 )
@@ -26,6 +25,7 @@ from amrita_core.types import (
     UniResponse,
 )
 
+from .consts import BUILTIN_TOOLS_NAME, HYBRID_TEMPLATE, REASONING_TEMPLATE
 from .tools import (
     PROCESS_MESSAGE,
     REASONING_TOOL,
@@ -75,26 +75,7 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
     origin_instruction: str = ""
     reasoning_pc = 0
     _suggested_stop: bool = False  # Flag to switch tool_choice from required to auto
-    _reasoning_template = Template(""""
-    Please analyze the task requirements based on the user input above,summarize the current step's purpose and reasons, and execute accordingly.
-    If no task needs to be performed, no description is needed;
-    please analyze according to the character tone set in <ROLE_SETTINGS> (if present).
-    {% if last_step %}
-    Your previous task was:
-
-    ```text
-    {{last_step}}
-    ```
-    {% endif %}
-    {% if original_msg %}
-    <INPUT>
-    {{original_msg}}
-    </INPUT>
-    {% endif %}
-    <ROLE_SETTINGS>
-    {{stg.ctx.get_original_context().train.content}}
-    </ROLE_SETTINGS>
-    """)
+    _reasoning_template = REASONING_TEMPLATE
 
     def __init__(self, ctx: StrategyContext):
         super().__init__(ctx)
@@ -450,8 +431,11 @@ class NoActionAgentStrategy(AgentStrategy):
         cls,
     ) -> Literal["workflow"]:
         return "workflow"
+
+
 # TODO: Resolve https://github.com/AmritaBot/AmritaCore/issues/20
 # class CompatibleReActAgentStrategy(BaseReActAgentStrategy):
+
 
 class HybridReActAgentStrategy(BaseReActAgentStrategy):
     """**Hybrid ReAct Agent Strategy optimized for Mixture of Experts (MoE) architecture models.**
@@ -535,16 +519,7 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
         # Standalone closing tags
         (re.compile(r"</(?i:TOOL_CALL|TOOL_RESULT|PARAMS|PARAM)>", re.IGNORECASE), ""),
     ]
-    _tool_call_jinja2: Template = Template("""<TOOL_CALL name="{{tool_name}}">
-        <PARAMS>
-            {% for key,value in params.items() %}
-            <PARAM name="{{key}}">{{value}}</PARAM>
-            {% endfor %}
-        </PARAMS>
-    </TOOL_CALL>
-    <TOOL_RESULT name="{{tool_name}}">
-    {{result}}
-    </TOOL_RESULT>""")
+    _tool_call_jinja2: Template = HYBRID_TEMPLATE
     _process_message: list[str]
 
     def __init__(self, *args, **kwargs):
@@ -620,6 +595,25 @@ class HybridReActAgentStrategy(BaseReActAgentStrategy):
     async def _handle_loop_reasoning_cleanup(self, prompt: str):
         """Hybrid strategy: clear _process_message when loop is detected."""
         self._process_message = []
+
+    @override
+    async def _build_stop_response_and_append(
+        self,
+        function_args: dict[str, Any],
+        response_msg: UniResponse[None, list[ToolCall] | None],
+    ):
+        """Hybrid strategy: append stop instructions as user message with XML-like format.
+
+        Unlike ReActAgentStrategy which adds an assistant message, Hybrid strategy
+        adds the stop instructions as a user message to maintain consistency with
+        its context-based integration approach.
+        """
+        self.ctx.message.append(
+            Message(
+                role="user",
+                content=self._build_stop_response(function_args),
+            )
+        )
 
     @override
     async def on_post_process(self) -> None:

--- a/src/amrita_core/builtins/consts.py
+++ b/src/amrita_core/builtins/consts.py
@@ -1,3 +1,5 @@
+from jinja2 import Template
+
 from amrita_core.builtins.tools import PROCESS_MESSAGE, REASONING_TOOL, STOP_TOOL
 
 BUILTIN_TOOLS_NAME = {
@@ -11,3 +13,35 @@ AGENT_PROCESS_TOOLS = (
     STOP_TOOL,
     PROCESS_MESSAGE,
 )
+
+HYBRID_TEMPLATE = Template("""<TOOL_CALL name="{{tool_name}}">
+    <PARAMS>
+        {% for key,value in params.items() %}
+        <PARAM name="{{key}}">{{value}}</PARAM>
+        {% endfor %}
+    </PARAMS>
+</TOOL_CALL>
+<TOOL_RESULT name="{{tool_name}}">
+    {{result}}
+</TOOL_RESULT>""")
+
+REASONING_TEMPLATE = Template(""""
+Please analyze the task requirements based on the user input above,summarize the current step's purpose and reasons, and execute accordingly.
+If no task needs to be performed, no description is needed;
+please analyze according to the character tone set in <ROLE_SETTINGS> (if present).
+{% if last_step %}
+Your previous task was:
+
+```text
+{{last_step}}
+```
+{% endif %}
+{% if original_msg %}
+<INPUT>
+{{original_msg}}
+</INPUT>
+{% endif %}
+<ROLE_SETTINGS>
+{{stg.ctx.get_original_context().train.content}}
+</ROLE_SETTINGS>
+""")

--- a/src/amrita_core/chatmanager.py
+++ b/src/amrita_core/chatmanager.py
@@ -933,6 +933,8 @@ class ChatObject:
                 raise
             with contextlib.suppress(NoExceptionHandler):
                 await st.on_exception(e)
+        else:
+            await st.on_post_process()
         self.context_wrap.extend(ctx.original_context.end_messages)
 
     @suspend

--- a/src/amrita_core/chatmanager.py
+++ b/src/amrita_core/chatmanager.py
@@ -586,6 +586,7 @@ class ChatObject:
         """Decorator for suspend.(Only be used for a time-costy function)"""
         if not iscoroutinefunction(func):
             raise TypeError(f"{func.__name__} is not a coroutine function.")
+
         @wraps(func)
         async def wrapper(*args, **kwargs):
             chat_object = None
@@ -910,7 +911,7 @@ class ChatObject:
                     else self.context_wrap.copy()
                 )
                 ctx = StrategyContext(self.user_input, context, self)
-                await self._run_agent(ctx)
+                return await self._run_agent(ctx)
 
             case "rag":
                 context = SendMessageWrap.validate_messages(
@@ -945,6 +946,7 @@ class ChatObject:
                     break
             else:
                 await strategy.on_limited()
+            await strategy.on_post_process()
             self.context_wrap.extend(strategy.ctx.original_context.end_messages)
 
         except Exception as e:

--- a/src/amrita_core/protocol.py
+++ b/src/amrita_core/protocol.py
@@ -59,6 +59,9 @@ class RawMessageContent(MessageContent, ABC):
     def get_content(self):
         return self.raw_data
 
+    def __str__(self) -> str:
+        return str(self.raw_data)
+
 
 class StringMessageContent(MessageContent):
     """String type message content implementation"""
@@ -140,7 +143,8 @@ class ImageMessage(MessageContent):
         image_type = get_image_format(self.image)
         if not image_type:
             return "[Unsupported image format]"
-        return f"![](data:image/{image_type};base64,{self.image.decode('utf-8')})"
+        base64_data = base64.b64encode(self.image).decode("utf-8")
+        return f"![](data:image/{image_type};base64,{base64_data})"
 
     async def save_to(self, path: Path, headers: dict | None = None):
         async with aiofiles.open(path, "wb") as f:

--- a/src/amrita_core/protocol.py
+++ b/src/amrita_core/protocol.py
@@ -186,6 +186,8 @@ class ModelAdapter:
     ) -> UniResponse[None, list[ToolCall] | None]:
         raise NotImplementedError
 
+    # TODO: Add embedding/reranker support.
+
     @staticmethod
     @abstractmethod
     def get_adapter_protocol() -> str | tuple[str, ...]: ...

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -39,7 +39,6 @@ from amrita_core.types import (
     SendMessageWrap,
     TextContent,
     ToolCall,
-    ToolResult,
     UniResponse,
 )
 
@@ -523,10 +522,12 @@ async def test_template_method_execute_tool_loop_no_calls(mock_strategy_context)
     """Test _execute_tool_loop returns False when no tool calls."""
     strategy = ReActAgentStrategy(mock_strategy_context)
 
-    mock_response = UniResponse(content=None, tool_calls=None, usage=None)
-    msg_list = mock_strategy_context.original_context
-
-    result = await strategy._execute_tool_loop(mock_response, msg_list, lambda: False)
+    mock_response: UniResponse[None, list[ToolCall] | None] = UniResponse(
+        content=None, tool_calls=[], usage=None
+    )
+    result = await strategy._execute_tool_loop(
+        mock_response,
+    )
     assert result is False
 
 
@@ -554,7 +555,7 @@ async def test_hybrid_vs_react_append_difference(mock_strategy_context, mock_con
     mock_strategy_context.chat_object.config = mock_config
 
     # Mock a successful tool call
-    mock_response: UniResponse[None, list[ToolCall]] = UniResponse(
+    mock_response: UniResponse[None, list[ToolCall] | None] = UniResponse(
         content=None,
         tool_calls=[
             ToolCall(
@@ -587,23 +588,23 @@ async def test_hybrid_vs_react_append_difference(mock_strategy_context, mock_con
         data=ToolFunctionSchema(function=tool_def, type="function", strict=False),
         custom_run=False,
     )
-
-    manager = ToolsManager()
-    manager.register_tool(tool_data)
+    react_strategy = ReActAgentStrategy(mock_strategy_context)
+    react_strategy.tools = [{"name": "test_tool"}]
+    original_get_tool = react_strategy.tools_manager.get_tool
 
     try:
-        # Test ReAct strategy - should append Message + ToolResult objects
-        react_strategy = ReActAgentStrategy(mock_strategy_context)
-        react_strategy.tools = [{"name": "test_tool"}]
+        # Mock the tools manager to return our tool
+        react_strategy.tools_manager.get_tool = MagicMock(return_value=tool_data)
 
-        initial_count = len(mock_strategy_context.original_context.memory)
+        initial_count = len(mock_strategy_context.original_context.end_messages)
         await react_strategy._execute_tool_loop(
-            mock_response, mock_strategy_context.original_context, lambda: False
+            mock_response,
         )
-        react_count = len(mock_strategy_context.original_context.memory)
+        react_count = len(mock_strategy_context.original_context.end_messages)
 
-        # ReAct should add both assistant message and tool result
-        assert react_count > initial_count
+        # ReAct should add both assistant message and tool result (2 messages to end_messages)
+        assert react_count == initial_count + 2
 
     finally:
-        manager.remove_tool("test_tool")
+        # Restore original get_tool method to avoid polluting other tests
+        react_strategy.tools_manager.get_tool = original_get_tool

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,9 +3,10 @@ Unit tests for AmritaCore Agent Strategy system.
 
 This module tests the new Agent Strategy architecture including:
 - AgentStrategy abstract base class
-- ReActAgentStrategy implementation
+- ReActAgentStrategy and HybridReActAgentStrategy implementations
 - StrategyContext data class
 - Built-in constants and tools
+- Template method pattern execution flow
 """
 
 from typing import Literal
@@ -15,7 +16,11 @@ import pytest
 
 from amrita_core.agent.context import StrategyContext
 from amrita_core.agent.strategy import AgentStrategy, NoExceptionHandler
-from amrita_core.builtins.agent import ReActAgentStrategy
+from amrita_core.builtins.agent import (
+    BaseReActAgentStrategy,
+    HybridReActAgentStrategy,
+    ReActAgentStrategy,
+)
 from amrita_core.builtins.consts import (
     AGENT_PROCESS_TOOLS,
     BUILTIN_TOOLS_NAME,
@@ -33,6 +38,9 @@ from amrita_core.types import (
     Message,
     SendMessageWrap,
     TextContent,
+    ToolCall,
+    ToolResult,
+    UniResponse,
 )
 
 
@@ -60,6 +68,9 @@ def mock_chat_object(mock_config):
     chat_obj.config = mock_config
     chat_obj.yield_response = AsyncMock()
     chat_obj.set_queue_done = AsyncMock()
+    train_msg = Message(role="system", content="Test system message")
+    chat_obj.train = train_msg
+
     return chat_obj
 
 
@@ -225,6 +236,7 @@ def test_strategy_context_with_complex_user_input(create_send_message_wrap):
     mock_chat_obj.session_id = "test-session"
     mock_chat_obj.preset = "default-preset"
     mock_chat_obj.config = AmritaConfig()
+    mock_chat_obj.train = train_msg
 
     ctx = StrategyContext(
         user_input=user_content,
@@ -309,6 +321,7 @@ async def test_amrita_agent_strategy_single_execute_stop_tool(
     mock_config.builtin.tool_calling_mode = "agent"
     mock_config.builtin.agent_thought_mode = "none"
     mock_strategy_context.chat_object.config = mock_config
+    mock_strategy_context.chat_object.train.content = "Test"
 
     # Mock tools_caller to return STOP tool call
     mock_response = UniResponse(
@@ -398,3 +411,199 @@ async def test_amrita_agent_strategy_single_execute_tool_error(
     finally:
         # Clean up the registered tool
         manager.remove_tool("failing_tool")
+
+
+# ============================================================================
+# Tests for HybridReActAgentStrategy and Template Method Pattern
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_hybrid_react_agent_strategy_initialization(mock_strategy_context):
+    """Test HybridReActAgentStrategy initialization with text sanitization."""
+    strategy = HybridReActAgentStrategy(mock_strategy_context)
+
+    # Test that origin_msg is sanitized
+    assert isinstance(strategy.origin_msg, str)
+    assert strategy._process_message == []
+
+
+@pytest.mark.asyncio
+async def test_hybrid_react_agent_strategy_sanitize_text():
+    """Test HybridReActAgentStrategy text sanitization removes XML tags."""
+    from amrita_core.agent.context import StrategyContext
+    from amrita_core.chatmanager import ChatObject
+    from amrita_core.config import AmritaConfig
+    from amrita_core.types import Message, SendMessageWrap
+
+    # Create context with malicious XML tags
+    user_content = "<TOOL_CALL>malicious</TOOL_CALL><PARAMS>data</PARAMS>"
+    user_msg = Message(role="user", content=user_content)
+    train_msg = Message(role="system", content="System")
+    original_context = SendMessageWrap(
+        train=train_msg, memory=[user_msg], user_query=user_msg
+    )
+
+    mock_chat_obj = MagicMock(spec=ChatObject)
+    mock_chat_obj.session_id = "test"
+    mock_chat_obj.preset = "default"
+    mock_chat_obj.config = AmritaConfig()
+    mock_chat_obj.train = train_msg
+
+    ctx = StrategyContext(
+        user_input=user_content,
+        original_context=original_context,
+        chat_object=mock_chat_obj,
+    )
+
+    strategy = HybridReActAgentStrategy(ctx)
+    # Tags should be removed
+    assert "<TOOL_CALL>" not in strategy.origin_msg
+    assert "<PARAMS>" not in strategy.origin_msg
+
+
+@pytest.mark.asyncio
+async def test_hybrid_react_agent_strategy_render_tool():
+    """Test HybridReActAgentStrategy _render_tool method."""
+    strategy = HybridReActAgentStrategy.__new__(HybridReActAgentStrategy)
+
+    tool_call = ToolCall(
+        id="tool1",
+        function={"name": "test_tool", "arguments": '{"param1": "value1"}'},  # pyright: ignore[reportArgumentType]
+    )
+
+    rendered = strategy._render_tool(tool_call, "result_data")
+    assert "<TOOL_CALL" in rendered
+    assert "<TOOL_RESULT" in rendered
+    assert "test_tool" in rendered
+    assert "result_data" in rendered
+
+
+@pytest.mark.asyncio
+async def test_base_react_agent_build_stop_response():
+    """Test BaseReActAgentStrategy._build_stop_response static method."""
+    # Test without result
+    response1 = BaseReActAgentStrategy._build_stop_response({})
+    assert "BEGIN_OF_INSTRUCTIONS" in response1
+    assert "END_OF_INSTRUCTIONS" in response1
+    assert "Work summary" not in response1
+
+    # Test with result
+    response2 = BaseReActAgentStrategy._build_stop_response({"result": "Done"})
+    assert "Work summary" in response2
+    assert "Done" in response2
+
+
+@pytest.mark.asyncio
+async def test_base_react_agent_check_loop_reasoning(
+    mock_strategy_context, mock_config
+):
+    """Test BaseReActAgentStrategy._check_and_handle_loop_reasoning."""
+    mock_config.builtin.loop_reasoning_trigger = 2
+    mock_strategy_context.chat_object.config = mock_config
+    mock_strategy_context.chat_object.stream_id = "test-stream"
+
+    strategy = ReActAgentStrategy(mock_strategy_context)
+
+    # Below threshold - should return None
+    strategy.reasoning_pc = 1
+    result1 = strategy._check_and_handle_loop_reasoning()
+    assert result1 is None
+
+    # Above threshold - should return prompt
+    strategy.reasoning_pc = 3
+    result2 = strategy._check_and_handle_loop_reasoning()
+    assert result2 is not None
+    assert "Loop reasoning triggered" in result2
+    assert len(mock_strategy_context.original_context.end_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_template_method_execute_tool_loop_no_calls(mock_strategy_context):
+    """Test _execute_tool_loop returns False when no tool calls."""
+    strategy = ReActAgentStrategy(mock_strategy_context)
+
+    mock_response = UniResponse(content=None, tool_calls=None, usage=None)
+    msg_list = mock_strategy_context.original_context
+
+    result = await strategy._execute_tool_loop(mock_response, msg_list, lambda: False)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_hybrid_strategy_post_process(mock_strategy_context):
+    """Test HybridReActAgentStrategy.on_post_process adds end message."""
+    strategy = HybridReActAgentStrategy(mock_strategy_context)
+    strategy.call_count = 2  # Must be >= 2
+
+    await strategy.on_post_process()
+
+    # Check that END_OF_PROCESS message was added
+    assert len(mock_strategy_context.original_context.end_messages) > 0
+    last_msg = mock_strategy_context.original_context.end_messages[-1]
+    assert "END_OF_PROCESS" in last_msg.content
+
+
+@pytest.mark.asyncio
+async def test_hybrid_vs_react_append_difference(mock_strategy_context, mock_config):
+    """Test that Hybrid and ReAct strategies append results differently."""
+    from amrita_core.types import ToolCall, UniResponse
+
+    mock_config.builtin.tool_calling_mode = "agent"
+    mock_config.builtin.agent_thought_mode = "none"
+    mock_strategy_context.chat_object.config = mock_config
+
+    # Mock a successful tool call
+    mock_response: UniResponse[None, list[ToolCall]] = UniResponse(
+        content=None,
+        tool_calls=[
+            ToolCall(
+                id="tool1",
+                function={"name": "test_tool", "arguments": "{}"},  # pyright: ignore[reportArgumentType]
+            )
+        ],
+        usage=None,
+    )
+
+    # Register a simple tool
+    async def simple_tool(*args, **kwargs):
+        return "Tool output"
+
+    from amrita_core.tools.models import (
+        FunctionDefinitionSchema,
+        FunctionParametersSchema,
+        ToolData,
+        ToolFunctionSchema,
+    )
+
+    tool_def = FunctionDefinitionSchema(
+        name="test_tool",
+        description="Test tool",
+        parameters=FunctionParametersSchema(type="object", properties={}),
+    )
+
+    tool_data = ToolData(
+        func=simple_tool,
+        data=ToolFunctionSchema(function=tool_def, type="function", strict=False),
+        custom_run=False,
+    )
+
+    manager = ToolsManager()
+    manager.register_tool(tool_data)
+
+    try:
+        # Test ReAct strategy - should append Message + ToolResult objects
+        react_strategy = ReActAgentStrategy(mock_strategy_context)
+        react_strategy.tools = [{"name": "test_tool"}]
+
+        initial_count = len(mock_strategy_context.original_context.memory)
+        await react_strategy._execute_tool_loop(
+            mock_response, mock_strategy_context.original_context, lambda: False
+        )
+        react_count = len(mock_strategy_context.original_context.memory)
+
+        # ReAct should add both assistant message and tool result
+        assert react_count > initial_count
+
+    finally:
+        manager.remove_tool("test_tool")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,97 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amrita_core.builtins.hooks import cookie, posthook
+from amrita_core.config import AmritaConfig
+from amrita_core.hook.event import CompletionEvent
+from amrita_core.protocol import MessageWithMetadata
+
+
+class TestHooks:
+    @pytest.fixture
+    def mock_config(self):
+        config = AmritaConfig()
+        config.cookie.enable_cookie = True
+        config.cookie.cookie = "test_cookie_value"
+        return config
+
+    @pytest.fixture
+    def mock_event(self):
+        event = MagicMock(spec=CompletionEvent)
+        chat_object = AsyncMock()
+        event.chat_object = chat_object
+        return event
+
+    @pytest.mark.asyncio
+    async def test_cookie_hook_with_cookie_found(self, mock_event, mock_config):
+        """Test cookie hook when cookie is found in response"""
+        mock_response = "This is a test response with test_cookie_value in it"
+        mock_event.get_model_response.return_value = mock_response
+
+        await cookie(mock_event, mock_config)
+
+        # Verify that error response was yielded
+        mock_event.chat_object.yield_response.assert_called_once()
+        call_args = mock_event.chat_object.yield_response.call_args
+        response_obj = call_args[1]["response"]
+
+        assert isinstance(response_obj, MessageWithMetadata)
+        assert response_obj.content == "Some error occurred, please try again later."
+        assert response_obj.metadata["type"] == "error"
+        assert response_obj.metadata["extra_type"] == "cookie"
+
+        # Verify that queue was marked as done
+        mock_event.chat_object.set_queue_done.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cookie_hook_without_cookie_found(self, mock_event, mock_config):
+        """Test cookie hook when cookie is NOT found in response"""
+        mock_response = "This is a normal response without the cookie"
+        mock_event.get_model_response.return_value = mock_response
+
+        await cookie(mock_event, mock_config)
+
+        # Verify that no error response was yielded
+        mock_event.chat_object.yield_response.assert_not_called()
+        mock_event.chat_object.set_queue_done.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cookie_hook_with_cookie_disabled(self, mock_event):
+        """Test cookie hook when cookie detection is disabled"""
+        config = AmritaConfig()
+        config.cookie.enable_cookie = False
+        config.cookie.cookie = "test_cookie_value"
+
+        mock_response = "This response contains test_cookie_value but detection is off"
+        mock_event.get_model_response.return_value = mock_response
+
+        await cookie(mock_event, config)
+
+        # Verify that no error response was yielded
+        mock_event.chat_object.yield_response.assert_not_called()
+        mock_event.chat_object.set_queue_done.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cookie_hook_with_empty_cookie(self, mock_event):
+        """Test cookie hook when cookie value is empty"""
+        config = AmritaConfig()
+        config.cookie.enable_cookie = True
+        config.cookie.cookie = ""
+
+        mock_response = "Any response content"
+        mock_event.get_model_response.return_value = mock_response
+
+        await cookie(mock_event, config)
+
+        # Verify that no error response was yielded (empty cookie should not trigger)
+        mock_event.chat_object.yield_response.assert_not_called()
+        mock_event.chat_object.set_queue_done.assert_not_called()
+
+    def test_posthook_decorator(self):
+        """Test that posthook decorator is properly configured"""
+        assert hasattr(posthook, "handle")
+        assert callable(posthook.handle)
+        # Check that it's configured as a completion hook with correct parameters
+        assert posthook.block is False
+        assert posthook.priority == 10

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -180,11 +180,10 @@ def test_python_type_to_json_type():
 def test_on_tools_decorator():
     # Clean up ToolsManager before test
     manager = ToolsManager()
-    manager._models.clear()
-    manager._disabled_tools.clear()
+    manager._instance = None
 
     function_def = FunctionDefinitionSchema(
-        name="decorated_tool",
+        name="decorated_tool1",
         description="A decorated tool",
         parameters=FunctionParametersSchema(type="object", properties={}),
     )
@@ -193,11 +192,11 @@ def test_on_tools_decorator():
     async def test_function(params):
         return "result"
 
-    tool = manager.get_tool("decorated_tool")
+    tool = manager.get_tool("decorated_tool1")
     assert tool is not None
-    assert tool.data.function.name == "decorated_tool"
+    assert tool.data.function.name == "decorated_tool1"
 
-    manager.remove_tool("decorated_tool")
+    manager.remove_tool("decorated_tool1")
 
 
 @pytest.mark.asyncio
@@ -208,7 +207,7 @@ async def test_simple_tool_decorator():
     manager._disabled_tools.clear()
 
     @simple_tool
-    def add_numbers(a: int, b: int) -> int:
+    def add_number(a: int, b: int) -> int:
         """Add two numbers together.
 
         Args:
@@ -220,10 +219,10 @@ async def test_simple_tool_decorator():
         """
         return a + b
 
-    tool = manager.get_tool("add_numbers")
+    tool = manager.get_tool("add_number")
 
     if tool is not None:
         result = await tool.func({"a": 5, "b": 3})  # type: ignore
         assert result == "8"  # Note: simple_tool converts result to string
 
-    manager.remove_tool("add_numbers")
+    manager.remove_tool("add_number")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -69,6 +70,32 @@ class TestMCPClient:
             )
             mock_close.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_simple_call_with_exception(self, mcp_client):
+        """Test simple_call when exception occurs"""
+        with (
+            patch.object(mcp_client, "_connect"),
+            patch.object(mcp_client, "_close"),
+        ):
+            mock_client = AsyncMock()
+            mock_client.call_tool.side_effect = Exception("Test error")
+            mcp_client.mcp_client = mock_client
+
+            result = await mcp_client.simple_call("test_tool", {"param": "value"})
+
+            # Should return JSON error response
+            error_data = json.loads(result)
+            assert error_data["success"] is False
+            assert "Test error" in error_data["error"]
+
+    @pytest.mark.asyncio
+    async def test_connect_already_connected(self, mcp_client):
+        """Test _connect when already connected"""
+        mcp_client.mcp_client = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="MCP Server is already connected!"):
+            await mcp_client._connect()
+
 
 class TestMultiClientManager:
     @pytest.fixture
@@ -115,6 +142,14 @@ class TestMultiClientManager:
         assert len(manager.clients) == 1
         assert manager.clients[0] == client
 
+    def test_register_only_without_args(self):
+        """Test register_only without required arguments"""
+        manager = MultiClientManager()
+        with pytest.raises(
+            ValueError, match="Please provide MCP Server script or MCP Client"
+        ):
+            manager.register_only()  # type: ignore
+
     @pytest.mark.asyncio
     async def test_initialize_this(self):
         manager = MultiClientManager()
@@ -128,6 +163,12 @@ class TestMultiClientManager:
         # Test tools wrapper
         wrapper = manager._tools_wrapper("test_tool")
         assert callable(wrapper)
+
+    @pytest.mark.asyncio
+    async def test_get_client_by_tool_name_not_found(self, manager):
+        """Test get_client_by_tool_name when tool doesn't exist"""
+        with pytest.raises(RuntimeError, match="Tool not found: nonexistent_tool"):
+            await manager.get_client_by_tool_name("nonexistent_tool")
 
 
 class TestClientManager:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,272 @@
+import asyncio
+from io import BytesIO
+
+import pytest
+
+from amrita_core.config import AmritaConfig, set_config
+from amrita_core.protocol import (
+    AdapterManager,
+    ImageMessage,
+    MessageContent,
+    MessageWithMetadata,
+    ModelAdapter,
+    RawMessageContent,
+    StringMessageContent,
+    get_image_format,
+)
+from amrita_core.types import ModelPreset
+
+
+# Initialize config for tests
+@pytest.fixture(autouse=True)
+def setup_config():
+    """Initialize AmritaConfig for tests"""
+    set_config(AmritaConfig())
+
+
+class TestMessageContent:
+    def test_abstract_message_content(self):
+        """Test that MessageContent is abstract and cannot be instantiated"""
+        with pytest.raises(TypeError):
+            MessageContent("test")  # type: ignore
+
+    def test_string_message_content(self):
+        """Test StringMessageContent functionality"""
+        text = "Hello, world!"
+        msg = StringMessageContent(text)
+
+        assert msg.type == "string"
+        assert msg.text == text
+        assert msg.get_content() == text
+        assert str(msg) == text
+
+    def test_raw_message_content(self):
+        """Test RawMessageContent functionality"""
+        raw_data = {"key": "value", "number": 42}
+        msg = RawMessageContent(raw_data)
+
+        assert msg.type == "raw"
+        assert msg.raw_data == raw_data
+        assert msg.get_content() == raw_data
+        assert str(msg) == str(raw_data)
+
+    def test_message_with_metadata(self):
+        """Test MessageWithMetadata functionality"""
+        content = "Test message"
+        metadata = {"type": "info", "extra_type": "notification", "content": "details"}
+        msg = MessageWithMetadata(content, metadata)
+
+        assert msg.type == "metadata"
+        assert msg.content == content
+        assert msg.metadata == metadata
+        assert msg.get_content() == content
+        assert msg.get_metadata() == metadata
+        assert msg.get_full_content() == {"content": content, "metadata": metadata}
+        assert str(msg) == content
+
+
+class TestImageMessage:
+    @pytest.fixture
+    def sample_image_bytes(self):
+        # Create a simple PNG header for testing
+        return b"\x89PNG\r\n\x1a\n" + b"\x00" * 20  # Minimal PNG signature + dummy data
+
+    def test_image_message_initialization(self, sample_image_bytes):
+        """Test ImageMessage initialization with different input types"""
+        # Test with URL string
+        url_msg = ImageMessage("https://example.com/image.png")
+        assert url_msg.image == "https://example.com/image.png"
+
+        # Test with BytesIO
+        bytesio_msg = ImageMessage(BytesIO(sample_image_bytes))
+        assert isinstance(bytesio_msg.image, BytesIO)
+
+        # Test with bytes
+        bytes_msg = ImageMessage(sample_image_bytes)
+        assert bytes_msg.image == sample_image_bytes
+
+    def test_get_image_format_with_valid_png(self, sample_image_bytes):
+        """Test get_image_format with valid PNG data"""
+        result = get_image_format(sample_image_bytes)
+        assert result == "png"
+
+    def test_get_image_format_with_invalid_data(self):
+        """Test get_image_format with invalid image data"""
+        invalid_data = b"This is not an image"
+        result = get_image_format(invalid_data)
+        assert result is None
+
+    def test_image_message_get_content_url(self):
+        """Test ImageMessage get_content with URL"""
+        url = "https://example.com/image.png"
+        msg = ImageMessage(url)
+        assert msg.get_content() == f"![]({url})"
+
+    def test_image_message_get_content_bytes(self, sample_image_bytes):
+        """Test ImageMessage get_content with bytes"""
+        msg = ImageMessage(sample_image_bytes)
+        content = msg.get_content()
+        assert content.startswith("![](data:image/png;base64,")
+
+    def test_image_message_get_content_unsupported_format(self):
+        """Test ImageMessage get_content with unsupported format"""
+        unsupported_data = b"not an image format"
+        msg = ImageMessage(unsupported_data)
+        assert msg.get_content() == "[Unsupported image format]"
+
+    # Skip complex curl tests for now as they require more sophisticated mocking
+    @pytest.mark.skip(reason="Complex aiohttp mocking requires more setup")
+    @pytest.mark.asyncio
+    async def test_image_message_curl_image(self):
+        pass
+
+    @pytest.mark.skip(reason="Complex aiohttp mocking requires more setup")
+    @pytest.mark.asyncio
+    async def test_image_message_curl_image_error(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_image_message_save_to(self, tmp_path, sample_image_bytes):
+        """Test ImageMessage save_to method"""
+        test_file = tmp_path / "test_image.png"
+
+        # Test with bytes
+        msg = ImageMessage(sample_image_bytes)
+        await msg.save_to(test_file)
+        assert test_file.exists()
+        assert test_file.read_bytes() == sample_image_bytes
+
+        # Test with BytesIO
+        bytesio_msg = ImageMessage(BytesIO(sample_image_bytes))
+        test_file2 = tmp_path / "test_image2.png"
+        await bytesio_msg.save_to(test_file2)
+        assert test_file2.exists()
+
+
+class TestAdapterManager:
+    def test_singleton_pattern(self):
+        """Test AdapterManager singleton pattern"""
+        manager1 = AdapterManager()
+        manager2 = AdapterManager()
+        assert manager1 is manager2
+
+    def test_adapter_registration_and_retrieval(self):
+        """Test adapter registration and retrieval"""
+        manager = AdapterManager()
+
+        # Clear existing adapters for clean test
+        manager._adapter_class.clear()
+
+        class TestAdapter(ModelAdapter):
+            __abstract__ = True  # Mark as abstract to avoid auto-registration
+
+            @staticmethod
+            def get_adapter_protocol():
+                return "test-protocol"
+
+        # Register adapter manually
+        manager.register_adapter(TestAdapter)
+
+        # Retrieve adapter
+        retrieved = manager.get_adapter("test-protocol")
+        assert retrieved == TestAdapter
+
+        # Test safe_get_adapter
+        safe_retrieved = manager.safe_get_adapter("test-protocol")
+        assert safe_retrieved == TestAdapter
+
+        # Test safe_get_adapter with non-existent protocol
+        none_retrieved = manager.safe_get_adapter("non-existent")
+        assert none_retrieved is None
+
+        # Test get_adapter with non-existent protocol (should raise)
+        with pytest.raises(ValueError, match="No adapter found for protocol"):
+            manager.get_adapter("non-existent")
+
+    def test_adapter_override_functionality(self):
+        """Test adapter override functionality"""
+        manager = AdapterManager()
+        manager._adapter_class.clear()
+
+        class OriginalAdapter(ModelAdapter):
+            __abstract__ = True
+
+            @staticmethod
+            def get_adapter_protocol():
+                return "override-test"
+
+        class OverrideAdapter(ModelAdapter):
+            __abstract__ = True
+            __override__ = True
+
+            @staticmethod
+            def get_adapter_protocol():
+                return "override-test"
+
+        # Register original adapter
+        manager.register_adapter(OriginalAdapter)
+
+        # Register override adapter (should work due to __override__ = True)
+        manager.register_adapter(OverrideAdapter)
+
+        # Verify override worked
+        retrieved = manager.get_adapter("override-test")
+        assert retrieved == OverrideAdapter
+
+    def test_multiple_protocol_registration(self):
+        """Test registration with multiple protocols"""
+        manager = AdapterManager()
+        manager._adapter_class.clear()
+
+        class MultiProtocolAdapter(ModelAdapter):
+            __abstract__ = True
+
+            @staticmethod
+            def get_adapter_protocol():
+                return ("protocol1", "protocol2", "protocol3")
+
+        manager.register_adapter(MultiProtocolAdapter)
+
+        for protocol in ["protocol1", "protocol2", "protocol3"]:
+            retrieved = manager.get_adapter(protocol)
+            assert retrieved == MultiProtocolAdapter
+
+    def test_protocol_type_validation(self):
+        """Test protocol type validation"""
+        manager = AdapterManager()
+        manager._adapter_class.clear()
+
+        class InvalidProtocolAdapter(ModelAdapter):
+            __abstract__ = True
+
+            @staticmethod
+            def get_adapter_protocol():  # type: ignore
+                return ("valid", 123)  # Contains non-string
+
+        with pytest.raises(
+            TypeError,
+            match="Model protocol adapter must be a string or tuple of strings",
+        ):
+            manager.register_adapter(InvalidProtocolAdapter)
+
+
+class TestModelAdapterAbstractMethods:
+    def test_model_adapter_abstract_methods(self):
+        """Test that ModelAdapter abstract methods raise NotImplementedError"""
+
+        class ConcreteAdapter(ModelAdapter):
+            __abstract__ = True
+
+            @staticmethod
+            def get_adapter_protocol():
+                return "concrete-test"
+
+        adapter = ConcreteAdapter(ModelPreset(name="test", base_url="test"))
+
+        # Test call_tools raises NotImplementedError
+        with pytest.raises(NotImplementedError):
+            asyncio.run(adapter.call_tools([], []))
+
+        # Test get_adapter_protocol works
+        assert adapter.get_adapter_protocol() == "concrete-test"
+        assert adapter.protocol == "concrete-test"

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "amrita-core"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "amrita-core"
-version = "0.7.1.post1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new template-based ReAct agent architecture with shared core logic, add specialized Hybrid and NoAction strategies, extend lifecycle hooks and security hooks, and update protocol handling, adapters, tests, and documentation accordingly.

New Features:
- Add BaseReActAgentStrategy as a shared abstract template-method base for ReAct-style agent strategies.
- Introduce HybridReActAgentStrategy optimized for MoE models using XML-tagged tool call/result embedding into conversation context.
- Add NoActionAgentStrategy as a workflow strategy that deliberately skips tool execution.
- Expose an on_post_process lifecycle hook for all strategy categories to support post-execution context modifications.
- Add stricter message filtering for AnthropicAdapter to drop invalid assistant/tool messages before API calls.

Bug Fixes:
- Fix incorrect markdown generation for image messages by encoding raw bytes instead of decoding as UTF-8.
- Ensure ChatObject strategy execution always returns from _run_strategy and invokes on_post_process on successful completion.
- Prevent Anthropic API calls from including invalid assistant/tool messages by filtering them out in the adapter.
- Tighten MCP client and MultiClientManager behavior when already connected or misconfigured, raising clear errors.

Enhancements:
- Refactor ReActAgentStrategy to reuse shared execution flow, improve loop detection, stop handling, and error handling via the new base class.
- Improve cookie security and post-completion hooks documentation and API reference, clarifying built-in hooks and lifecycle behavior.
- Clarify and expand agent strategy, built-in agent system, and lifecycle documentation in both English and Chinese, including new strategy selection guidance.
- Improve image message handling by correctly base64-encoding raw image bytes in markdown output and adding __str__ to RawMessageContent for consistency.
- Update docs navigation to include new strategy and client classes in the API reference and fix Jinja2 template doc links.

Build:
- Add helper shell scripts to initialize a uv-based virtual environment and run the test suite with coverage.

Documentation:
- Document BaseReActAgentStrategy, HybridReActAgentStrategy, and NoActionAgentStrategy in the API reference (EN/zh).
- Expand agent strategy guides (EN/zh) with template-method architecture, built-in strategies, examples, and post-process hook usage.
- Enhance built-in adapter and agent system docs (EN/zh) with Anthropic message filtering, security considerations, and strategy selection guidelines.
- Add lifecycle documentation for on_post_process and other strategy methods in the function-implementation guides (EN/zh).

Tests:
- Add comprehensive tests for HybridReActAgentStrategy, BaseReActAgentStrategy loop handling, and differences from ReActAgentStrategy.
- Add protocol-layer tests for message content types, AdapterManager behavior, and ModelAdapter abstract method enforcement.
- Add hook tests for cookie safety and post-completion hooks.
- Extend MCP client and MultiClientManager tests to cover error paths and edge cases.
- Adjust existing tool manager tests to use unique tool names and avoid cross-test interference.

Chores:
- Bump project version from 0.7.2 to 0.7.3.