### PR TITLE
Refactor ChatObject agent loop state and dedupe strategy base

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,9 +48,6 @@ jobs:
         with:
           python-path: ${{ env.PYTHON_BIN }}
           pylance-version: latest-release
-      - name: Add dependencies
-        run: uv pip install .
-
       - name: Run Unit Tests with JUnit XML output
         run: uv run pytest tests/ --cov=src/amrita_core --cov-report=term-missing
           --cov-report=xml --junitxml=test-results.xml -v

--- a/docs/docs/guide/api-reference/classes/ChatObject.md
+++ b/docs/docs/guide/api-reference/classes/ChatObject.md
@@ -264,25 +264,6 @@ The `jinja2_vars` parameter allows you to pass custom variables to the Jinja2 te
 
 This design provides maximum flexibility for template customization while maintaining safety by preventing accidental conflicts with built-in variables.
 
-### Parameters
-
-- **`train`** (`dict[str, str] | Message[str]`): System message or training data that defines the agent's behavior
-- **`user_input`** (`str | list[TextContent | ImageContent]`): User's input message
-- **`context`** (`MemoryModel | None`): Conversation memory context (optional)
-- **`session_id`** (`str`): Unique identifier for the conversation session
-- **`callback`** (`Callable[[str | MessageContent], Awaitable[Any]] | None`, optional): Async callback function that receives response chunks as they are generated. Defaults to `None`.
-- **`config`** (`AmritaConfig | None`, optional): Configuration for this chat instance. Defaults to global config.
-- **`preset`** (`ModelPreset | None`, optional): Model preset configuration. Defaults to session or global default.
-- **`auto_create_session`** (`bool`, optional): Whether to automatically create a session if it doesn't exist. Defaults to `False`.
-- **`train_template`** (`Template`, optional): Jinja2 template for formatting system messages. Defaults to built-in template.
-- **`jinja2_vars`** (`dict[str, Any] | None`, optional): Variables to pass to the Jinja2 template system.
-- **`agent_strategy`** (`type[AgentStrategy]`, optional): Agent execution strategy. Defaults to `ReActAgentStrategy`.
-- **`hook_args`** (`tuple[Any, ...]`, optional): Arguments passed to matcher functions. Defaults to empty tuple.
-- **`hook_kwargs`** (`dict[str, Any] | None`, optional): Keyword arguments passed to matcher functions.
-- **`exception_ignored`** (`tuple[type[BaseException], ...]`, optional): Exception types that should be re-raised if they occur in matcher functions.
-- **`queue_size`** (`int`, optional): Maximum buffer size for the response stream. Uses AnyIO's memory object stream with built-in backpressure instead of the previous dual-queue overflow mechanism. Defaults to `45`.
-- **`queue_timeout`** (`float | None`, optional): Timeout for queue operations in seconds. If `None`, operations will wait indefinitely. Defaults to `10.0`.
-
 ### Streaming Response Processing
 
 AmritaCore uses **AnyIO memory object streams** for streaming responses, which provides built-in backpressure handling:

--- a/docs/docs/zh/guide/api-reference/classes/ChatObject.md
+++ b/docs/docs/zh/guide/api-reference/classes/ChatObject.md
@@ -264,25 +264,6 @@ ChatObject 类负责处理单个聊天会话，包括消息接收、上下文管
 
 这种设计为模板自定义提供了最大的灵活性，同时通过防止与内置变量的意外冲突来保持安全性。
 
-### 参数
-
-- **`train`** (`dict[str, str] | Message[str]`): 定义Agent行为的系统消息或训练数据
-- **`user_input`** (`str | list[TextContent | ImageContent]`): 用户输入消息
-- **`context`** (`MemoryModel | None`): 对话内存上下文（可选）
-- **`session_id`** (`str`): 对话会话的唯一标识符
-- **`callback`** (`Callable[[str | MessageContent], Awaitable[Any]] | None`, 可选): 异步回调函数，在生成响应块时接收它们。默认为 `None`。
-- **`config`** (`AmritaConfig | None`, 可选): 此聊天实例的配置。默认为全局配置。
-- **`preset`** (`ModelPreset | None`, 可选): 模型预设配置。默认为会话或全局默认值。
-- **`auto_create_session`** (`bool`, 可选): 如果会话不存在是否自动创建。默认为 `False`。
-- **`train_template`** (`Template`, 可选): 用于格式化系统消息的Jinja2模板。默认为内置模板。
-- **`jinja2_vars`** (`dict[str, Any] | None`, 可选): 传递给Jinja2模板系统的变量。
-- **`agent_strategy`** (`type[AgentStrategy]`, 可选): Agent执行策略。默认为 `ReActAgentStrategy`。
-- **`hook_args`** (`tuple[Any, ...]`, 可选): 传递给匹配器函数的参数。默认为空元组。
-- **`hook_kwargs`** (`dict[str, Any] | None`, 可选): 传递给匹配器函数的关键字参数。
-- **`exception_ignored`** (`tuple[type[BaseException], ...]`, 可选): 如果在匹配器函数中发生，应该重新抛出的异常类型。
-- **`queue_size`** (`int`, 可选): 响应流的最大缓冲区大小。使用AnyIO的内存对象流与内置背压，而不是之前的双队列溢出机制。默认为 `45`。
-- **`queue_timeout`** (`float | None`, 可选): 队列操作的超时时间（秒）。如果为 `None`，操作将无限等待。默认为 `10.0`。
-
 ### 流式响应处理
 
 AmritaCore使用**AnyIO内存对象流**进行流式响应，提供内置的背压处理：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 "Source" = "https://github.com/AmritaBot/AmritaCore"
 "Issue Tracker" = "https://github.com/AmritaBot/AmritaCore/issues"
 
+[tool.uv]
+package=true
+
 [dependency-groups]
 dev = [
     "ruff>=0.12.8",

--- a/src/amrita_core/agent/strategy.py
+++ b/src/amrita_core/agent/strategy.py
@@ -27,7 +27,189 @@ class NoExceptionHandler(Exception):
     pass
 
 
-class StrategyLikedObject(ABC):
+class _StrategyBase(ABC):
+    """Shared execution logic for AgentStrategy and StrategyLikedObject, which
+    differ only in how the context is injected (``__init__`` vs ``__call__``)."""
+
+    session: SessionData | None = None
+    tools_manager: "MultiToolsManager"
+    chat_object: "ChatObject"
+    ctx: StrategyContext
+
+    def _bind(self, ctx: StrategyContext) -> None:
+        self.ctx = ctx
+        self.chat_object = ctx.chat_object
+        session_id = ctx.chat_object.session_id
+        self.session = SessionsManager().get_session_data(session_id, None)
+        self.tools_manager = self.session.tools if self.session else ToolsManager()
+
+    async def single_execute(
+        self,
+    ) -> bool:
+        """
+        Execute a single agent step for 'agent' and 'agent-mixed' category strategies.
+
+        This method is called by the framework to perform one iteration of tool calling.
+        The framework handles the loop management, call counting, and termination conditions.
+
+        For 'agent' category strategies, this method should:
+        - Process the current message context
+        - Make tool calls as needed
+        - Return True to continue execution, False to stop
+
+        For 'agent-mixed' category strategies, this method should:
+        - Dynamically determine whether to operate in RAG mode or Agent mode based on context
+        - Handle both retrieval-augmented generation and iterative tool calling within the same execution flow
+        - Return True to continue execution, False to stop
+
+        Returns:
+            True if should continue to next execution, False to stop.
+
+        Note:
+            This method is used by 'agent' and 'agent-mixed' category strategies.
+            'rag' and 'workflow' category strategies should implement run() instead.
+        """
+        raise NotImplementedError
+
+    async def run(self) -> None:
+        """
+        Run the complete agent strategy for 'rag' and 'workflow' category strategies.
+
+        This method gives full control to the strategy implementation for managing:
+        - Tool calling iterations and limits
+        - Context construction and management
+        - Error handling and recovery
+        - Response generation and streaming
+
+        Category-specific behavior:
+        - 'rag': Should use minimal context containing only system message and user query,
+                 without historical conversation context. Typically performs retrieval and
+                 generates a single response without iterative tool calling.
+        - 'workflow': Has complete manual control over everything including tool calling
+                     times management, context building, and execution flow. Can implement
+                      complex multi-step workflows with custom logic.
+
+        Note:
+            This method is used by 'rag' and 'workflow' category strategies.
+            'agent' and 'agent-mixed' category strategies should implement single_execute() instead.
+        """
+        raise NotImplementedError
+
+    async def call_tool(self, tool_call: ToolCall) -> str:
+        """Execute a single tool call without modifying the agent's context.
+
+        This is a one-step tool execution that processes the given tool call
+        and returns its response. It does not alter the agent's internal state
+        or context beyond what the tool itself might do through the provided
+        ToolContext.
+
+        Args:
+            tool_call (ToolCall): The ToolCall object containing the function name and arguments
+
+        Raises:
+            RuntimeError: If the requested tool is not found in the tools manager
+
+        Returns:
+            str: The string response from the tool execution, or a default message if the tool returns None
+        """
+        function_name = tool_call.function.name
+        function_args: dict[str, Any] = json.loads(tool_call.function.arguments)
+        if (tool_data := self.tools_manager.get_tool(function_name)) is not None:
+            if not tool_data.custom_run:
+                func_response: str | None = await typing.cast(
+                    Callable[[dict[str, Any]], Awaitable[str]],
+                    tool_data.func,
+                )(function_args)
+            elif (
+                func_response := await typing.cast(
+                    Callable[[ToolContext], Awaitable[str | None]],
+                    tool_data.func,
+                )(
+                    ToolContext(
+                        data=function_args,
+                        ctx=self.ctx,
+                    )
+                )
+            ) is None:
+                func_response = "(this tool returned no content)"
+            return func_response
+        else:
+            raise RuntimeError("Received unexpected tool call")
+
+    async def on_limited(self) -> None:
+        """
+        Handle the event when the agent reaches its tool calling limit.
+
+        This method is called when the agent strategy has reached the maximum allowed number of tool calls
+        as configured by the framework. It provides a callback mechanism to handle special behavior or
+        actions required when the tool usage limit is exceeded.
+
+        Common use cases include:
+        - Sending a notification message to the user about the limit being reached
+        - Providing alternative responses without further tool calls
+        - Logging the limit event for monitoring purposes
+
+        Note:
+            This method is used by 'agent' and 'agent-mixed' category strategies.
+            'rag' and 'workflow' category strategies should implement run() instead.
+        """
+        await self.chat_object.io_stream.yield_response(
+            MessageWithMetadata(
+                content="[AmritaAgent] Too many tool calls! Workflow terminated!",
+                metadata=MessageMetadataPayloadSystem(
+                    type="system",
+                    message="[AmritaAgent] Too many tool calls! Workflow terminated!",
+                    extra_type="tool_call_limit",
+                ),
+            )
+        )
+        self.ctx.original_context.append(
+            Message(
+                role="user",
+                content="Too much tools called occurred,please call later or follow user's instruction."
+                + "Now please continue to completion and NOT to call ANY tools.",
+            )
+        )
+
+    async def on_exception(self, exc: BaseException) -> None:
+        pass
+
+    async def on_post_process(self) -> None:
+        """Used to process after all steps are completed successfully"""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_category(cls) -> Literal["agent", "workflow", "rag", "agent-mixed"]:
+        """
+        Get the category of the agent strategy.
+
+        The category determines how the strategy is executed by the framework:
+
+        - "agent": Framework-managed iterative execution using single_execute().
+                   The framework handles the execution loop, call counting, and termination.
+                   Strategy focuses on single-step logic. Best for standard tool-calling agents.
+
+        - "rag": Minimal-context execution using run(). Only receives system message and
+                 user query without conversation history. Designed for Retrieval-Augmented
+                 Generation scenarios where external knowledge retrieval is the primary function.
+
+        - "agent-mixed": Mixed-mode execution using single_execute(). Can handle both RAG and Agent modes.
+                         Dynamically switches between retrieval-augmented generation and iterative
+                         tool calling based on the current context and requirements. Provides
+                         flexibility to adapt execution strategy during runtime.
+
+        - "workflow": Full manual control using run(). Strategy manages everything including
+                      tool calling limits, context construction, and execution flow. Suitable
+                      for complex multi-step workflows with custom orchestration logic.
+
+        Returns:
+            The strategy category as a literal string indicating execution pattern.
+        """
+        ...
+
+
+class StrategyLikedObject(_StrategyBase, ABC):
     """Abstract base class for agent strategy **instances**.
 
     Unlike ``AgentStrategy`` which receives a **type** (``type[AgentStrategy]``)
@@ -75,11 +257,6 @@ class StrategyLikedObject(ABC):
             configuration.
     """
 
-    session: SessionData | None
-    tools_manager: "MultiToolsManager"
-    chat_object: "ChatObject"
-    ctx: StrategyContext
-
     def __call__(self, ctx: StrategyContext) -> Self:
         """Populate runtime context.
 
@@ -87,180 +264,11 @@ class StrategyLikedObject(ABC):
         Subclasses may override this to perform additional initialisation, but
         **must** call ``super().__call__(ctx)`` first.
         """
-        self.ctx = ctx
-        self.chat_object = ctx.chat_object
-        session_id = ctx.chat_object.session_id
-        self.session = SessionsManager().get_session_data(session_id, None)
-        self.tools_manager = self.session.tools if self.session else ToolsManager()
+        self._bind(ctx)
         return self
 
-    async def single_execute(
-        self,
-    ) -> bool:
-        """
-        Execute a single agent step for 'agent' and 'agent-mixed' category strategies.
 
-        This method is called by the framework to perform one iteration of tool calling.
-        The framework handles the loop management, call counting, and termination conditions.
-
-        For 'agent' category strategies, this method should:
-        - Process the current message context
-        - Make tool calls as needed
-        - Return True to continue execution, False to stop
-
-        For 'agent-mixed' category strategies, this method should:
-        - Dynamically determine whether to operate in RAG mode or Agent mode based on context
-        - Handle both retrieval-augmented generation and iterative tool calling within the same execution flow
-        - Return True to continue execution, False to stop
-
-        Returns:
-            True if should continue to next execution, False to stop.
-
-        Note:
-            This method is used by 'agent' and 'agent-mixed' category strategies.
-            'rag' and 'workflow' category strategies should implement run() instead.
-        """
-        raise NotImplementedError
-
-    async def run(self) -> None:
-        """
-        Run the complete agent strategy for 'rag' and 'workflow' category strategies.
-
-        This method gives full control to the strategy implementation for managing:
-        - Tool calling iterations and limits
-        - Context construction and management
-        - Error handling and recovery
-        - Response generation and streaming
-
-        Category-specific behavior:
-        - 'rag': Should use minimal context containing only system message and user query,
-                 without historical conversation context. Typically performs retrieval and
-                 generates a single response without iterative tool calling.
-        - 'workflow': Has complete manual control over everything including tool calling
-                     times management, context building, and execution flow. Can implement
-                      complex multi-step workflows with custom logic.
-
-        Note:
-            This method is used by 'rag' and 'workflow' category strategies.
-            'agent' and 'agent-mixed' category strategies should implement single_execute() instead.
-        """
-        raise NotImplementedError
-
-    async def call_tool(self, tool_call: ToolCall) -> str:
-        """Execute a single tool call without modifying the agent's context.
-
-        This is a one-step tool execution that processes the given tool call
-        and returns its response. It does not alter the agent's internal state
-        or context beyond what the tool itself might do through the provided
-        ToolContext.
-
-        Args:
-            tool_call (ToolCall): The ToolCall object containing the function name and arguments
-
-        Raises:
-            RuntimeError: If the requested tool is not found in the tools manager
-
-        Returns:
-            str: The string response from the tool execution, or a default message if the tool returns None
-        """
-        function_name = tool_call.function.name
-        function_args: dict[str, Any] = json.loads(tool_call.function.arguments)
-        if (tool_data := self.tools_manager.get_tool(function_name)) is not None:
-            if not tool_data.custom_run:
-                func_response: str | None = await typing.cast(
-                    Callable[[dict[str, Any]], Awaitable[str]],
-                    tool_data.func,
-                )(function_args)
-            elif (
-                func_response := await typing.cast(
-                    Callable[[ToolContext], Awaitable[str | None]],
-                    tool_data.func,
-                )(
-                    ToolContext(
-                        data=function_args,
-                        ctx=self.ctx,
-                    )
-                )
-            ) is None:
-                func_response = "(this tool returned no content)"
-            return func_response
-        else:
-            raise RuntimeError("Received unexpected tool call")
-
-    async def on_limited(self) -> None:
-        """
-        Handle the event when the agent reaches its tool calling limit.
-
-        This method is called when the agent strategy has reached the maximum allowed number of tool calls
-        as configured by the framework. It provides a callback mechanism to handle special behavior or
-        actions required when the tool usage limit is exceeded.
-
-        Common use cases include:
-        - Sending a notification message to the user about the limit being reached
-        - Providing alternative responses without further tool calls
-        - Logging the limit event for monitoring purposes
-
-        Note:
-            This method is used by 'agent' and 'agent-mixed' category strategies.
-            'rag' and 'workflow' category strategies should implement run() instead.
-        """
-        await self.chat_object.io_stream.yield_response(
-            MessageWithMetadata(
-                content="[AmritaAgent] Too many tool calls! Workflow terminated!",
-                metadata=MessageMetadataPayloadSystem(
-                    type="system",
-                    message="[AmritaAgent] Too many tool calls! Workflow terminated!",
-                    extra_type="tool_call_limit",
-                ),
-            )
-        )
-        self.ctx.original_context.append(
-            Message(
-                role="user",
-                content="Too much tools called occurred,please call later or follow user's instruction."
-                + "Now please continue to completion and NOT to call ANY tools.",
-            )
-        )
-
-    async def on_exception(self, exc: BaseException) -> None:
-        pass
-
-    async def on_post_process(self) -> None:
-        """Used to process after all steps are completed successfully"""
-        pass
-
-    @classmethod
-    @abstractmethod
-    def get_category(cls) -> Literal["agent", "workflow", "rag", "agent-mixed"]:
-        """
-        Get the category of the agent strategy.
-
-        The category determines how the strategy is executed by the framework:
-
-        - "agent": Framework-managed iterative execution using single_execute().
-                   The framework handles the execution loop, call counting, and termination.
-                   Strategy focuses on single-step logic. Best for standard tool-calling agents.
-
-        - "rag": Minimal-context execution using run(). Only receives system message and
-                 user query without conversation history. Designed for Retrieval-Augmented
-                 Generation scenarios where external knowledge retrieval is the primary function.
-
-        - "agent-mixed": Mixed-mode execution using single_execute(). Can handle both RAG and Agent modes.
-                         Dynamically switches between retrieval-augmented generation and iterative
-                         tool calling based on the current context and requirements. Provides
-                         flexibility to adapt execution strategy during runtime.
-
-        - "workflow": Full manual control using run(). Strategy manages everything including
-                      tool calling limits, context construction, and execution flow. Suitable
-                      for complex multi-step workflows with custom orchestration logic.
-
-        Returns:
-            The strategy category as a literal string indicating execution pattern.
-        """
-        ...
-
-
-class AgentStrategy(ABC):
+class AgentStrategy(_StrategyBase, ABC):
     """
     Abstract base class for agent strategies that define how an agent should execute its workflow.
 
@@ -286,11 +294,6 @@ class AgentStrategy(ABC):
         ctx: The strategy context containing execution parameters and configuration
     """
 
-    session: SessionData | None = None
-    tools_manager: "MultiToolsManager"
-    chat_object: "ChatObject"
-    ctx: StrategyContext
-
     def __init__(self, ctx: StrategyContext) -> None:
         """
         Initialize the agent strategy with the provided context.
@@ -298,173 +301,4 @@ class AgentStrategy(ABC):
         Args:
             ctx: StrategyContext containing chat_object, configuration, and message context
         """
-        self.ctx = ctx
-        self.chat_object = ctx.chat_object
-        session_id = ctx.chat_object.session_id
-        self.session = SessionsManager().get_session_data(session_id, None)
-        self.tools_manager = self.session.tools if self.session else ToolsManager()
-
-    async def single_execute(
-        self,
-    ) -> bool:
-        """
-        Execute a single agent step for 'agent' and 'agent-mixed' category strategies.
-
-        This method is called by the framework to perform one iteration of tool calling.
-        The framework handles the loop management, call counting, and termination conditions.
-
-        For 'agent' category strategies, this method should:
-        - Process the current message context
-        - Make tool calls as needed
-        - Return True to continue execution, False to stop
-
-        For 'agent-mixed' category strategies, this method should:
-        - Dynamically determine whether to operate in RAG mode or Agent mode based on context
-        - Handle both retrieval-augmented generation and iterative tool calling within the same execution flow
-        - Return True to continue execution, False to stop
-
-        Returns:
-            True if should continue to next execution, False to stop.
-
-        Note:
-            This method is used by 'agent' and 'agent-mixed' category strategies.
-            'rag' and 'workflow' category strategies should implement run() instead.
-        """
-        raise NotImplementedError
-
-    async def run(self) -> None:
-        """
-        Run the complete agent strategy for 'rag' and 'workflow' category strategies.
-
-        This method gives full control to the strategy implementation for managing:
-        - Tool calling iterations and limits
-        - Context construction and management
-        - Error handling and recovery
-        - Response generation and streaming
-
-        Category-specific behavior:
-        - 'rag': Should use minimal context containing only system message and user query,
-                 without historical conversation context. Typically performs retrieval and
-                 generates a single response without iterative tool calling.
-        - 'workflow': Has complete manual control over everything including tool calling
-                     times management, context building, and execution flow. Can implement
-                      complex multi-step workflows with custom logic.
-
-        Note:
-            This method is used by 'rag' and 'workflow' category strategies.
-            'agent' and 'agent-mixed' category strategies should implement single_execute() instead.
-        """
-        raise NotImplementedError
-
-    async def call_tool(self, tool_call: ToolCall) -> str:
-        """Execute a single tool call without modifying the agent's context.
-
-        This is a one-step tool execution that processes the given tool call
-        and returns its response. It does not alter the agent's internal state
-        or context beyond what the tool itself might do through the provided
-        ToolContext.
-
-        Args:
-            tool_call (ToolCall): The ToolCall object containing the function name and arguments
-
-        Raises:
-            RuntimeError: If the requested tool is not found in the tools manager
-
-        Returns:
-            str: The string response from the tool execution, or a default message if the tool returns None
-        """
-        function_name = tool_call.function.name
-        function_args: dict[str, Any] = json.loads(tool_call.function.arguments)
-        if (tool_data := self.tools_manager.get_tool(function_name)) is not None:
-            if not tool_data.custom_run:
-                func_response: str | None = await typing.cast(
-                    Callable[[dict[str, Any]], Awaitable[str]],
-                    tool_data.func,
-                )(function_args)
-            elif (
-                func_response := await typing.cast(
-                    Callable[[ToolContext], Awaitable[str | None]],
-                    tool_data.func,
-                )(
-                    ToolContext(
-                        data=function_args,
-                        ctx=self.ctx,
-                    )
-                )
-            ) is None:
-                func_response = "(this tool returned no content)"
-            return func_response
-        else:
-            raise RuntimeError("Received unexpected tool call")
-
-    async def on_limited(self) -> None:
-        """
-        Handle the event when the agent reaches its tool calling limit.
-
-        This method is called when the agent strategy has reached the maximum allowed number of tool calls
-        as configured by the framework. It provides a callback mechanism to handle special behavior or
-        actions required when the tool usage limit is exceeded.
-
-        Common use cases include:
-        - Sending a notification message to the user about the limit being reached
-        - Providing alternative responses without further tool calls
-        - Logging the limit event for monitoring purposes
-
-        Note:
-            This method is used by 'agent' and 'agent-mixed' category strategies.
-            'rag' and 'workflow' category strategies should implement run() instead.
-        """
-        await self.chat_object.io_stream.yield_response(
-            MessageWithMetadata(
-                content="[AmritaAgent] Too many tool calls! Workflow terminated!",
-                metadata=MessageMetadataPayloadSystem(
-                    type="system",
-                    message="[AmritaAgent] Too many tool calls! Workflow terminated!",
-                    extra_type="tool_call_limit",
-                ),
-            )
-        )
-        self.ctx.original_context.append(
-            Message(
-                role="user",
-                content="Too much tools called occurred,please call later or follow user's instruction."
-                + "Now please continue to completion and NOT to call ANY tools.",
-            )
-        )
-
-    async def on_exception(self, exc: BaseException) -> None:
-        pass
-
-    async def on_post_process(self) -> None:
-        """Used to process after all steps are completed successfully"""
-        pass
-
-    @classmethod
-    @abstractmethod
-    def get_category(cls) -> Literal["agent", "workflow", "rag", "agent-mixed"]:
-        """
-        Get the category of the agent strategy.
-
-        The category determines how the strategy is executed by the framework:
-
-        - "agent": Framework-managed iterative execution using single_execute().
-                   The framework handles the execution loop, call counting, and termination.
-                   Strategy focuses on single-step logic. Best for standard tool-calling agents.
-
-        - "rag": Minimal-context execution using run(). Only receives system message and
-                 user query without conversation history. Designed for Retrieval-Augmented
-                 Generation scenarios where external knowledge retrieval is the primary function.
-
-        - "agent-mixed": Mixed-mode execution using single_execute(). Can handle both RAG and Agent modes.
-                         Dynamically switches between retrieval-augmented generation and iterative
-                         tool calling based on the current context and requirements. Provides
-                         flexibility to adapt execution strategy during runtime.
-
-        - "workflow": Full manual control using run(). Strategy manages everything including
-                      tool calling limits, context construction, and execution flow. Suitable
-                      for complex multi-step workflows with custom orchestration logic.
-
-        Returns:
-            The strategy category as a literal string indicating execution pattern.
-        """
-        ...
+        self._bind(ctx)

--- a/src/amrita_core/chatmanager/chat_object.py
+++ b/src/amrita_core/chatmanager/chat_object.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 from asyncio import Task
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
 from io import StringIO
@@ -79,6 +80,16 @@ RESPONSE_CALLBACK_TYPE = Callable[[RESPONSE_TYPE], Awaitable[Any]] | None
 FUNC_RET_T = TypeVar("FUNC_RET_T")
 
 
+@dataclass
+class AgentLoopState:
+    """Transient state for the framework-managed agent loop."""
+
+    stg_ctx: StrategyContext
+    strategy: AgentStrategy | StrategyLikedObject | None = None
+    ctx_backup: SendMessageWrap | None = None
+    called_count: int = 0
+
+
 class ChatObject:
     """Chat processing object - The minimal unit of chat processing.
 
@@ -144,11 +155,8 @@ class ChatObject:
         Callable[[Self], Awaitable[Any]] | None
     )  # Middleware for the whole workflow, will be set in __init__.
 
-    # Agent Temp (lateinit)
-    _tmp_strategy: AgentStrategy | StrategyLikedObject
-    _ctx_backup_tmp: SendMessageWrap
-    _stg_ctx_tmp: StrategyContext
-    _agt_called_count: int
+    # Agent loop state
+    _agent_loop: AgentLoopState | None = None
 
     # Manager
     _chatman: ChatManager
@@ -194,7 +202,6 @@ class ChatObject:
             middleware (Callable[[Self],Awaitable[Any]] | None, optional): Middleware for the whole workflow. Defaults to None.
             exception_ignored (tuple[type[BaseException], ...], optional): These exceptions will be raised again if they are raised in the Matcher function. Defaults to ().
         """
-        global chat_manager
         sm = SessionsManager()
         if auto_create_session and not sm.is_session_registered(session_id):
             sm.init_session(session_id)
@@ -223,7 +230,7 @@ class ChatObject:
             prompt_tokens=0, completion_tokens=0, total_tokens=0
         )
         self._chatman = chat_man or chat_manager
-        self._agt_called_count = 0
+        self._agent_loop = None
         # other
         self.last_call = datetime.now(utc)
         self.preset = preset or (
@@ -577,7 +584,7 @@ async def _run_strategy(chat_obj: ChatObject, intp: WorkflowInterpreter) -> None
                 else chat_obj.context_wrap.copy()
             )
             ctx = StrategyContext(chat_obj.user_input, context, chat_obj)
-            chat_obj._stg_ctx_tmp = ctx
+            chat_obj._agent_loop = AgentLoopState(stg_ctx=ctx)
             return intp.jump_to(intp.find_addr_alias(BuiltinName.AGENT_STRATEGY))
 
         case "rag":
@@ -607,23 +614,31 @@ async def _run_strategy(chat_obj: ChatObject, intp: WorkflowInterpreter) -> None
 
 @Node()
 def _agent_entry(chat_obj: ChatObject) -> None:
-    chat_obj._tmp_strategy = chat_obj.strategy(chat_obj._stg_ctx_tmp)
-    chat_obj._ctx_backup_tmp = chat_obj.context_wrap.copy()
+    loop = chat_obj._agent_loop
+    assert loop is not None
+    loop.strategy = chat_obj.strategy(loop.stg_ctx)
+    loop.ctx_backup = chat_obj.context_wrap.copy()
 
 
 @Node(SuspendEnum.ADVANCE_COUNTER, False)
 async def _advance_ctr(chat_obj: ChatObject):
+    loop = chat_obj._agent_loop
+    assert loop is not None
+    assert loop.strategy is not None
     max_times: int = chat_obj.config.function_config.agent_tool_call_limit + 1
-    if chat_obj._agt_called_count > max_times:
-        await chat_obj._tmp_strategy.on_limited()
+    if loop.called_count > max_times:
+        await loop.strategy.on_limited()
         raise BreakLoop(f"Counter has reached the maximum limit of {max_times}")
-    chat_obj._agt_called_count += 1
+    loop.called_count += 1
 
 
 @Node(SuspendEnum.SINGLE_TOOL)
 async def _single_strategy_exec(chat_obj: ChatObject) -> bool:
+    loop = chat_obj._agent_loop
+    assert loop is not None
+    assert loop.strategy is not None
     try:
-        return await chat_obj._tmp_strategy.single_execute()
+        return await loop.strategy.single_execute()
     except Exception as e:
         if isinstance(e, chat_obj._raised_exc) or isinstance(
             e, chat_obj._interpreter._exc_ignored
@@ -640,20 +655,20 @@ async def _single_strategy_exec(chat_obj: ChatObject) -> bool:
                 ),
             )
         )
-        await chat_obj._tmp_strategy.on_exception(e)
-        chat_obj.context_wrap = chat_obj._ctx_backup_tmp
+        await loop.strategy.on_exception(e)
+        assert loop.ctx_backup is not None
+        chat_obj.context_wrap = loop.ctx_backup
         return False
 
 
 @Node()
 async def _strategy_post(chat_obj: ChatObject):
-    await chat_obj._tmp_strategy.on_post_process()
-    chat_obj.context_wrap.extend(
-        chat_obj._tmp_strategy.ctx.original_context.end_messages
-    )
-    del chat_obj._tmp_strategy
-    del chat_obj._ctx_backup_tmp
-    del chat_obj._stg_ctx_tmp
+    loop = chat_obj._agent_loop
+    assert loop is not None
+    assert loop.strategy is not None
+    await loop.strategy.on_post_process()
+    chat_obj.context_wrap.extend(loop.strategy.ctx.original_context.end_messages)
+    chat_obj._agent_loop = None
 
 
 @Node(SuspendEnum.LLM_CALL)

--- a/src/amrita_core/hook/event.py
+++ b/src/amrita_core/hook/event.py
@@ -61,14 +61,8 @@ class FallbackContext(BaseEvent[EventTypeEnum]):
     if not TYPE_CHECKING:
 
         def __setattr__(self, name: str, value: Any) -> None:
-            if hasattr(self, "_readonly"):
-                if name in self._readonly:
-                    raise AttributeError(
-                        f"Cannot modify attribute {name},"
-                        + " force change it by setattr `!important:<attr_name>`"
-                    )
-                elif name.startswith("!important:"):
-                    name = name[11:]
+            if hasattr(self, "_readonly") and name in self._readonly:
+                raise AttributeError(f"Cannot modify read-only attribute {name}")
             super().__setattr__(name, value)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ wheels = [
 [[package]]
 name = "amrita-core"
 version = "0.9.3"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -267,7 +267,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiologic", specifier = ">=0.16.0" },
-    { name = "amrita-core", extras = ["anthropic", "jieba"], marker = "extra == 'all'", virtual = "." },
+    { name = "amrita-core", extras = ["anthropic", "jieba"], marker = "extra == 'all'", editable = "." },
     { name = "amrita-sense", specifier = ">=0.3.0" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.84.0" },
     { name = "fastmcp", specifier = ">=3.2.0" },


### PR DESCRIPTION
懒的写 PR Body 了，修复的都是常识性问题。

## Summary by Sourcery

Refactor shared agent strategy execution logic and centralize agent loop state management in ChatObject.

Enhancements:
- Extract shared context-binding and execution helpers into a common strategy base class used by both AgentStrategy and StrategyLikedObject.
- Unify ChatObject agent loop temporary fields into a structured AgentLoopState dataclass for clearer lifecycle and state handling.
- Simplify event attribute immutability behavior by enforcing strict read-only protection without the previous '!important' override mechanism.