### PR TITLE
fix: make base backends ABC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.10.0"
+version = "0.10.1"
 description = "High performance, flexible, lightweight agent framework."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/amrita_core/base/backend.py
+++ b/src/amrita_core/base/backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from amrita_core.types import MemoryModel
 
 
-class AbilityBackend:
+class AbilityBackend(ABC):
     @abstractmethod
     async def load_ability_all(self, session_id: str) -> AbilityContext:
         """Load ability"""
@@ -28,7 +28,7 @@ class AbilityBackend:
     async def load_presets(self, session_id: str) -> MultiPresetManager: ...
 
 
-class MemoryBackend:
+class MemoryBackend(ABC):
     @abstractmethod
     async def load_memory(self, session_id: str) -> MemoryModel:
         """Load memory"""


### PR DESCRIPTION
## Summary by Sourcery

Define base backend interfaces as abstract base classes and bump the project patch version.

Enhancements:
- Make AbilityBackend and MemoryBackend inherit from ABC to enforce abstract method implementation.

Build:
- Bump project version from 0.10.0 to 0.10.1.