### PR TITLE
Preserve provider reasoning metadata and batch concurrent tool results

### DIFF
--- a/docs/docs/guide/agent-engineering/troubleshooting.md
+++ b/docs/docs/guide/agent-engineering/troubleshooting.md
@@ -48,7 +48,9 @@ the tool-result append dropped `reasoning_content`.
 
 **Fix**: both are fixed in v0.13 — the filter (`thinking_config.content_mode`)
 shallow-copies messages (`model_copy(deep=False)`) instead of mutating, and
-every assistant message append carries `response_msg.reasoning_content` back.
+every assistant message append carries the response's thinking fields back
+verbatim (`reasoning_content`, `reasoning_signature` and any provider extra
+— `Message` allows extra, so nothing is hard-coded).
 If you write a custom strategy, keep both rules: **never strip reasoning in
 place; always pass it back** — safe for every provider, mandatory for the ones
 above.
@@ -60,9 +62,12 @@ above.
 **Root cause**: every assistant message with `tool_calls` must be followed by
 matching `ToolResult` messages.
 
-**Fix**: the built-in strategies append **one assistant message per tool_call**
-with its `ToolResult` — never batch multiple calls into one assistant message
-unless you pair them all. Custom strategies: follow the same pairing rule (see
+**Fix**: the built-in strategies put **all tool_calls of one response into a
+single assistant message**, followed by **all** their `ToolResult`s (in call
+order — fully paired). One response is never split into multiple assistant
+messages: the reasoning text (`reasoning_content`) appears exactly once, and
+splitting would repeat it across messages — undefined behavior.
+Custom strategies: follow the same pairing rule (see
 [Agent Strategy](../concepts/agent-strategy.md)). Any context injection that
 splits a tool-call/result pair (e.g. plan-status notes) breaks the contract —
 AmritaCore injects those at Step boundaries only, never mid-pair.

--- a/docs/docs/zh/guide/agent-engineering/troubleshooting.md
+++ b/docs/docs/zh/guide/agent-engineering/troubleshooting.md
@@ -41,7 +41,9 @@ passed back"，非偶发——assistant 一旦产出推理，后续每次请求�
 
 **修复**：v0.13 均已修复——过滤器（`thinking_config.content_mode`）
 浅拷贝消息（`model_copy(deep=False)`）而非原地修改；每个 assistant 消息
-追加都带回 `response_msg.reasoning_content`。编写自定义策略时请遵守
+追加都**原样带回** `response_msg` 的思考字段（`reasoning_content`、
+`reasoning_signature` 及任何供应商 extra——`Message` 允许 extra，全量
+传递，不硬编码）。编写自定义策略时请遵守
 两条规则：**绝不在原地剥离 reasoning；始终原样回传**——对所有供应商
 都安全，对上述供应商则是必须。
 
@@ -52,8 +54,10 @@ passed back"，非偶发——assistant 一旦产出推理，后续每次请求�
 **根因**：每个带 `tool_calls` 的 assistant 消息必须紧跟匹配的
 `ToolResult` 消息。
 
-**修复**：内置策略为每个 tool_call 追加**一条 assistant 消息**及其
-`ToolResult`——绝不把多个调用塞进一条 assistant 消息，除非全部配对。
+**修复**：内置策略把**一次响应里的所有 tool_call 放进一条 assistant
+消息**，后面紧跟**全部** `ToolResult`（按调用顺序，全部配对）。绝不把
+同一响应拆成多条 assistant——思考正文（`reasoning_content`）只出现一次，
+强拆会让它在多条消息里重复出现，产生未定义行为。
 自定义策略遵循同样的配对规则（见 [Agent 策略](../concepts/agent-strategy.md)）。
 任何拆散 tool-call/result 配对的上下文注入（如计划状态注记）都会破坏契约
 ——AmritaCore 只在 Step 边界注入，绝不插在配对中间。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.13.2"
+version = "0.13.4"
 description = "High performance, flexible, lightweight agent framework."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/amrita_core/builtins/agent/react_base.py
+++ b/src/amrita_core/builtins/agent/react_base.py
@@ -1160,6 +1160,8 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
                 else:
                     # _run_tool_calls_concurrently already called _append_reasoning.
                     should_continue = True
+                # The pair was appended above (error) or by the runner
+                # (success) — never re-appended via the collected batch.
                 continue
 
             if is_stop:

--- a/src/amrita_core/builtins/agent/react_base.py
+++ b/src/amrita_core/builtins/agent/react_base.py
@@ -410,6 +410,36 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
         """
         return
 
+    def _assistant_fields_from_response(
+        self,
+        response_msg: UniResponse[None, list[ToolCall] | None] | None,
+    ) -> dict[str, Any]:
+        """Extract assistant-message fields from the provider response verbatim.
+
+        ``Message`` allows extra fields, so every field (``reasoning_content``,
+        ``reasoning_signature`` and any provider-specific extra) is carried
+        over as-is — nothing is hard-coded here.  ``role``/``content``/
+        ``tool_calls``/``usage``/``metadata`` are excluded because the caller
+        supplies them explicitly (the executed ``tool_calls``, the provider's
+        ``content`` and the fixed ``assistant`` role).
+        """
+        if response_msg is None:
+            return {}
+        return response_msg.model_dump(
+            exclude={"role", "content", "tool_calls", "usage", "metadata"},
+            exclude_none=True,
+        )
+
+    def _maybe_inject_tool_failure_hint(
+        self, tool_call: ToolCall, func_response: str
+    ) -> None:
+        """Optionally append failure guidance after a hard ``ERROR`` result.
+
+        Base implementation is a no-op; the built-in ReAct strategy appends
+        a one-shot revise hint when the result starts with ``ERROR``.
+        """
+        return
+
     def _detect_step_stall(self) -> bool:
         """Check whether the current Step is stalled (duplicate tool calls).
 
@@ -1106,8 +1136,10 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
             tuple[ToolCall, str, BaseException | None]
         ] = await self._run_tool_calls_concurrently(tool_calls)
 
-        #  Append results sequentially
+        #  Collect results, then append ONE assistant message with every
+        #  tool_call followed by all ToolResults (never split per call).
         result_msg_list: list[ToolResult] = []
+        collected: list[tuple[ToolCall, str, BaseException | None]] = []
         should_continue = True  # default: keep looping (old `ret` semantics)
         for tc, func_response, exc in concurrent_results:
             function_name = tc.function.name
@@ -1120,9 +1152,8 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
                     # concurrent runner); surface the error, don't swallow.
                     self.reasoning_pc = 0
                     await self._handle_error_append(
-                        function_name,
+                        tc,
                         func_response,
-                        tc.id,
                         original_exception=exc,
                         response_msg=response_msg,
                     )
@@ -1135,28 +1166,11 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
                 if not func_response:
                     # Reflection failed — correction already injected, continue.
                     continue
-                await self._build_stop_response_and_append(
-                    json.loads(tc.function.arguments),
-                    response_msg,
-                    function_name,
-                    tc.id,
-                    func_response,
-                )
-            elif func_response.startswith("ERR:"):
-                self.reasoning_pc = 0
-                await self._handle_error_append(
-                    function_name,
-                    func_response,
-                    tc.id,
-                    original_exception=exc,
-                    response_msg=response_msg,
-                )
+                # The STOP runner already reset reasoning_pc.
             else:
                 self.reasoning_pc = 0
-                await self._append_tool_result_to_context(
-                    tc, func_response, response_msg
-                )
 
+            collected.append((tc, func_response, exc))
             logger.debug(f"Function {function_name} returned: {func_response}")
             result_msg_list.append(
                 ToolResult(
@@ -1170,6 +1184,9 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
 
             prompt = self._check_and_handle_loop_reasoning()
             if prompt is not None:
+                # Flush the collected results before stopping early.
+                await self._append_tool_results_batch(response_msg, collected)
+                collected.clear()
                 await self._handle_loop_reasoning_cleanup(prompt)
                 await self.io_stream.yield_response(
                     MessageWithMetadata(
@@ -1186,6 +1203,8 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
                 should_continue = False
                 break
 
+        await self._append_tool_results_batch(response_msg, collected)
+
         #  Notify once with the complete result list.
         if result_msg_list:
             await self._notify_tool_calls(
@@ -1196,24 +1215,59 @@ class BaseReActAgentStrategy(AgentStrategy, ABC):
 
         return should_continue
 
+    async def _append_tool_results_batch(
+        self,
+        response_msg: UniResponse[None, list[ToolCall] | None],
+        results: list[tuple[ToolCall, str, BaseException | None]],
+    ) -> None:
+        """Append ONE assistant message with all tool_calls, then all results.
+
+        Concurrent tool calls are never split: the fabricated assistant
+        message carries every executed ``tool_call`` plus the provider's
+        original fields verbatim (``Message`` allows extra, so nothing is
+        hard-coded here), followed by one ``ToolResult`` per call in input
+        order — success, ``ERR:`` and stop responses alike.
+        """
+        if not results:
+            return
+        msg_list = self.ctx.message
+        msg_list.append(
+            Message(
+                role="assistant",
+                content=response_msg.content if response_msg else None,
+                tool_calls=[tc for tc, _, _ in results],
+                **self._assistant_fields_from_response(response_msg),
+            )
+        )
+        for tc, func_response, _exc in results:
+            msg_list.append(
+                ToolResult(
+                    role="tool",
+                    name=tc.function.name,
+                    content=func_response,
+                    tool_call_id=tc.id,
+                )
+            )
+            self._maybe_inject_tool_failure_hint(tc, func_response)
+
     async def _handle_error_append(
         self,
-        function_name: str,
+        tool_call: ToolCall,
         error_content: str,
-        tool_call_id: str,
         original_exception: BaseException | None = None,
         response_msg: UniResponse[None, list[ToolCall] | None] | None = None,
     ):
         """Handle appending error messages to context (strategy-specific).
 
         Args:
-            function_name: Name of the failed function.
+            tool_call: The failed tool call, kept verbatim on the fabricated
+                assistant message so the round-trip stays faithful.
             error_content: Formatted error message to append.
-            tool_call_id: ID of the failed tool call.
             original_exception: The original exception, or ``None`` when the error
                 was captured as a string during concurrent execution.
             response_msg: The provider response, used to carry ``reasoning_content``
-                back on the fabricated assistant message (thinking-mode round-trip).
+                and ``reasoning_signature`` back on the fabricated assistant
+                message (thinking-mode round-trip).
         """
         ...
 

--- a/src/amrita_core/builtins/agent/react_comm.py
+++ b/src/amrita_core/builtins/agent/react_comm.py
@@ -695,21 +695,19 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
         "insufficient tool messages following tool_calls message" API error when the
         model returns multiple tool_calls in one response.
 
-        When the provider returned ``reasoning_content`` (thinking mode,
-        e.g. DeepSeek), it is carried back verbatim on the assistant message —
-        providers require the reasoning to be passed back on subsequent
-        requests, otherwise the API rejects the payload with HTTP 400.
+        The fabricated assistant message mirrors the provider's response
+        verbatim: every field (``reasoning_content``, ``reasoning_signature``
+        and any extra — ``Message`` allows extra) is carried over as-is via
+        :meth:`_assistant_fields_from_response`, never hard-coded.
         """
         self._record_tool_signature(tool_call)
         msg_list = self.ctx.message
-        # Carry the provider's reasoning_content back (thinking round-trip).
-        reasoning = response_msg.reasoning_content if response_msg else None
         msg_list.append(
             Message(
                 role="assistant",
-                content=None,
+                content=response_msg.content if response_msg else None,
                 tool_calls=[tool_call],
-                reasoning_content=reasoning,
+                **self._assistant_fields_from_response(response_msg),
             )
         )
         msg_list.append(
@@ -724,6 +722,7 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
         # plan failure — teach the model to revise instead of retrying forever.
         self._maybe_inject_tool_failure_hint(tool_call, func_response)
 
+    @override
     def _maybe_inject_tool_failure_hint(
         self, tool_call: ToolCall, func_response: str
     ) -> None:
@@ -779,14 +778,15 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
         Only a single ToolCall is included in the assistant message to avoid the
         "insufficient tool messages following tool_calls message" API error.
 
-        The provider's ``reasoning_content`` (thinking mode) is carried back
-        on the assistant message for the thinking round-trip requirement.
+        The fabricated assistant message mirrors the provider's response
+        verbatim: every field (``reasoning_content``, ``reasoning_signature``
+        and any extra — ``Message`` allows extra) is carried over as-is via
+        :meth:`_assistant_fields_from_response`, never hard-coded.
         """
-        reasoning = response_msg.reasoning_content if response_msg else None
         self.ctx.message.append(
             Message(
                 role="assistant",
-                content=None,
+                content=response_msg.content if response_msg else None,
                 tool_calls=[
                     ToolCall(
                         id=function_call_id,
@@ -796,7 +796,7 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
                         ),
                     )
                 ],
-                reasoning_content=reasoning,
+                **self._assistant_fields_from_response(response_msg),
             )
         )
         self.ctx.message.append(
@@ -811,55 +811,42 @@ class ReActAgentStrategy(BaseReActAgentStrategy):
     @override
     async def _handle_error_append(
         self,
-        function_name: str,
+        tool_call: ToolCall,
         error_content: str,
-        tool_call_id: str,
         original_exception: BaseException | None = None,
         response_msg: UniResponse[None, list[ToolCall] | None] | None = None,
     ):
         """ReAct strategy: append error as an assistant+tool message pair.
 
-        An assistant message with a single ToolCall is prepended to satisfy the
-        OpenAI API requirement that every ToolResult must follow an assistant
-        message containing the corresponding tool_call.
-
-        When the provider returned ``reasoning_content`` (thinking mode), it is
-        carried back on the fabricated assistant message exactly like the
-        success path, so thinking-mode providers (DeepSeek even in OpenAI mode,
-        Anthropic with extended thinking) keep receiving their reasoning back.
+        The fabricated assistant message mirrors the provider's response
+        verbatim: the original ``tool_call`` plus every field (``reasoning_content``,
+        ``reasoning_signature`` and any extra — ``Message`` allows extra)
+        carried over as-is via :meth:`_assistant_fields_from_response`, never
+        hard-coded — the failure is marked only by the ``ERR:``-prefixed
+        ``ToolResult`` content.
 
         Args:
-            function_name: Name of the failed function
-            error_content: Formatted error message to append
-            tool_call_id: ID of the tool call
+            tool_call: The failed tool call, kept verbatim for the round-trip.
+            error_content: Formatted error message to append.
             original_exception: The original exception, or ``None`` when the
                 error was captured as a string during concurrent execution.
-            response_msg: The provider response whose ``reasoning_content`` is
-                carried back on the assistant message, or ``None``.
+            response_msg: The provider response whose assistant-message fields
+                are carried back verbatim, or ``None``.
         """
-        reasoning = response_msg.reasoning_content if response_msg else None
         self.ctx.message.append(
             Message(
                 role="assistant",
-                content=None,
-                tool_calls=[
-                    ToolCall(
-                        id=tool_call_id,
-                        function=Function(
-                            name=function_name,
-                            arguments="{}",
-                        ),
-                    )
-                ],
-                reasoning_content=reasoning,
+                content=response_msg.content if response_msg else None,
+                tool_calls=[tool_call],
+                **self._assistant_fields_from_response(response_msg),
             )
         )
         self.ctx.message.append(
             ToolResult(
                 role="tool",
-                name=function_name,
+                name=tool_call.function.name,
                 content=error_content,
-                tool_call_id=tool_call_id,
+                tool_call_id=tool_call.id,
             )
         )
 

--- a/src/amrita_core/consts.py
+++ b/src/amrita_core/consts.py
@@ -1,6 +1,7 @@
 from jinja2 import Template
 
-ABSTRACT_INSTRUCTION: str = """<SYS>
+ABSTRACT_INSTRUCTION: str = """\
+<SYS>
 You are a professional context summarizer, strictly following user instructions to perform summarization tasks.
 </SYS>
 
@@ -23,7 +24,8 @@ User input -> Direct summary output
 </FORMATTING>"""
 
 # train,memory,chatobj(ChatObject),config will be given to Jinja2
-PROMPT_TEMPLATE: str = """<SCHEMA>
+PROMPT_TEMPLATE: str = """\
+<SCHEMA>
 {% if config.cookie.enable_cookie %}
 <HIDDEN>{{ config.cookie.cookie }}</HIDDEN>
 {% endif %}
@@ -43,7 +45,8 @@ Your character setting is in the <SYSTEM_INSTRUCTIONS> tags, and the summary of 
 
 DEFAULT_TEMPLATE: Template = Template(PROMPT_TEMPLATE)
 
-DEFAULT_INSTRUCTIONS: str = """## Summary
+DEFAULT_INSTRUCTIONS: str = """\
+## Summary
 
 You are a helpful assistant with two distinct working modes: Information Processing Mode and Daily Conversation Mode. You switch modes based on the agent_stop tool call.
 By default, you start in Daily Conversation Mode. You may enter Information Processing Mode only when a task requires tool use.

--- a/tests/test_step_loop.py
+++ b/tests/test_step_loop.py
@@ -643,6 +643,51 @@ class TestStrategyStepLifecycle:
             for m in tool_msgs
         )
 
+    def test_reasoning_error_appended_once(self, strategy):
+        """A failed REASONING call appends exactly one assistant+tool pair.
+
+        The error branch surfaces via ``_handle_error_append`` and then
+        ``continue``s — the failed call never enters the collected batch,
+        so the batch helper cannot append it a second time.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from amrita_core.builtins.tools import REASONING_TOOL
+        from amrita_core.types import ToolCall, UniResponse
+
+        asyncio_run(strategy.intro_step("execute"))
+        tool_call = ToolCall(
+            id="r1",
+            function={
+                "name": REASONING_TOOL.function.name,
+                "arguments": "{}",
+            },  # pyright: ignore[reportArgumentType]
+        )
+        response_msg = UniResponse(
+            content=None,
+            tool_calls=[tool_call],
+            reasoning_content="thinking",
+            reasoning_signature="sig-r1",
+        )
+        with patch.object(
+            strategy,
+            "_generate_reasoning_content",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            should_continue = asyncio_run(strategy._execute_tool_loop(response_msg))
+        assert should_continue is True
+        msgs = strategy.ctx.message.unwrap(exclude_system=True)
+        # Exactly one assistant message and one tool message — never twice.
+        assistant_msgs = [m for m in msgs if m.role == "assistant" and m.tool_calls]
+        tool_msgs = [m for m in msgs if getattr(m, "role", None) == "tool"]
+        assert len(assistant_msgs) == 1
+        assert len(tool_msgs) == 1
+        # Verbatim reasoning fields on the fabricated assistant message.
+        assert assistant_msgs[0].reasoning_content == "thinking"
+        assert assistant_msgs[0].reasoning_signature == "sig-r1"
+        # The failure is marked only by the ERR: ToolResult content.
+        assert "ERR: Tool think_and_reason execution failed" in tool_msgs[0].content
+
     # Concurrent results must NOT be split: ONE assistant message with all
     # tool_calls (verbatim fields), then ALL ToolResults in input order.
 

--- a/tests/test_step_loop.py
+++ b/tests/test_step_loop.py
@@ -674,12 +674,14 @@ class TestStrategyStepLifecycle:
                 function={"name": "calc", "arguments": '{"expr": "1+1"}'},  # pyright: ignore[reportArgumentType]
             ),
         ]
-        response_msg = UniResponse(
-            content=None,
-            tool_calls=calls,
-            reasoning_content="thinking about the search",
-            reasoning_signature="sig-abc123",
-            provider_extra="keep-me",  # extra field must round-trip verbatim
+        response_msg = UniResponse.model_validate(
+            {
+                "content": None,
+                "tool_calls": calls,
+                "reasoning_content": "thinking about the search",
+                "reasoning_signature": "sig-abc123",
+                "provider_extra": "keep-me",  # extra field must round-trip verbatim
+            }
         )
 
         async def fake_call(tc):

--- a/tests/test_step_loop.py
+++ b/tests/test_step_loop.py
@@ -572,6 +572,149 @@ class TestStrategyStepLifecycle:
         assistant_msgs = [m for m in msgs if m.role == "assistant"]
         assert assistant_msgs[-1].reasoning_content is None
 
+    def test_append_tool_result_carries_reasoning_signature(self, strategy):
+        """Anthropic extended thinking: the signature must round-trip too.
+
+        Like ``reasoning_content``, the provider's ``reasoning_signature`` is
+        carried back verbatim on the fabricated assistant message — Anthropic
+        rejects requests whose assistant messages drop it.
+        """
+        from amrita_core.types import ToolCall, UniResponse
+
+        asyncio_run(strategy.intro_step("execute"))
+        tool_call = ToolCall(
+            id="t1",
+            function={"name": "search", "arguments": '{"q": "x"}'},  # pyright: ignore[reportArgumentType]
+        )
+        response_msg = UniResponse(
+            content=None,
+            tool_calls=[tool_call],
+            reasoning_content="thinking about the search",
+            reasoning_signature="sig-abc123",
+        )
+        asyncio_run(
+            strategy._append_tool_result_to_context(tool_call, "result", response_msg)
+        )
+        msgs = strategy.ctx.message.unwrap(exclude_system=True)
+        assistant_msgs = [m for m in msgs if m.role == "assistant"]
+        assert assistant_msgs[-1].reasoning_content == "thinking about the search"
+        assert assistant_msgs[-1].reasoning_signature == "sig-abc123"
+
+    def test_exec_one_error_append_carries_reasoning_signature(self, strategy):
+        """A raising tool must round-trip the signature and keep args verbatim.
+
+        The error branch fabricates the assistant message exactly like the
+        success path: original ``tool_call`` (arguments kept, not replaced
+        with "{}") plus ``reasoning_content`` / ``reasoning_signature``. The
+        failure is marked only by the ``ERR:``-prefixed ToolResult.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from amrita_core.types import ToolCall, UniResponse
+
+        asyncio_run(strategy.intro_step("execute"))
+        tool_call = ToolCall(
+            id="t1",
+            function={"name": "search", "arguments": '{"q": "x"}'},  # pyright: ignore[reportArgumentType]
+        )
+        response_msg = UniResponse(
+            content=None,
+            tool_calls=[tool_call],
+            reasoning_content="thinking about the search",
+            reasoning_signature="sig-abc123",
+        )
+        with patch.object(
+            strategy,
+            "call_tool",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            should_continue = asyncio_run(strategy._execute_tool_loop(response_msg))
+        assert should_continue is True
+        msgs = strategy.ctx.message.unwrap(exclude_system=True)
+        assistant_msgs = [m for m in msgs if m.role == "assistant"]
+        assert assistant_msgs, "expected an assistant tool-call message"
+        assert assistant_msgs[-1].reasoning_content == "thinking about the search"
+        assert assistant_msgs[-1].reasoning_signature == "sig-abc123"
+        # Original tool call kept verbatim (arguments round-trip, not "{}").
+        assert assistant_msgs[-1].tool_calls[0].function.arguments == '{"q": "x"}'
+        tool_msgs = [m for m in msgs if getattr(m, "role", None) == "tool"]
+        assert any(
+            "ERR: Tool search execution failed" in getattr(m, "content", "")
+            for m in tool_msgs
+        )
+
+    # Concurrent results must NOT be split: ONE assistant message with all
+    # tool_calls (verbatim fields), then ALL ToolResults in input order.
+
+    def test_concurrent_tool_calls_not_split(self, strategy):
+        """Concurrent tool calls stay together: one assistant message, all
+        results appended after it — success and failure alike.
+
+        The fabricated assistant message carries every tool_call plus the
+        provider's fields verbatim (extra fields included), followed by one
+        ToolResult per call; the failure is marked only by its ``ERR:``
+        ToolResult content.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from amrita_core.types import ToolCall, UniResponse
+
+        asyncio_run(strategy.intro_step("execute"))
+        calls = [
+            ToolCall(
+                id="t1",
+                function={"name": "search", "arguments": '{"q": "a"}'},  # pyright: ignore[reportArgumentType]
+            ),
+            ToolCall(
+                id="t2",
+                function={"name": "wiki", "arguments": '{"q": "b"}'},  # pyright: ignore[reportArgumentType]
+            ),
+            ToolCall(
+                id="t3",
+                function={"name": "calc", "arguments": '{"expr": "1+1"}'},  # pyright: ignore[reportArgumentType]
+            ),
+        ]
+        response_msg = UniResponse(
+            content=None,
+            tool_calls=calls,
+            reasoning_content="thinking about the search",
+            reasoning_signature="sig-abc123",
+            provider_extra="keep-me",  # extra field must round-trip verbatim
+        )
+
+        async def fake_call(tc):
+            if tc.id == "t3":
+                raise RuntimeError("boom")
+            return f"result-{tc.id}"
+
+        with patch.object(
+            strategy,
+            "call_tool",
+            new=AsyncMock(side_effect=fake_call),
+        ):
+            should_continue = asyncio_run(strategy._execute_tool_loop(response_msg))
+        assert should_continue is True
+        msgs = strategy.ctx.message.unwrap(exclude_system=True)
+        # Exactly ONE assistant tool-call message for all three calls.
+        assistant_msgs = [m for m in msgs if m.role == "assistant" and m.tool_calls]
+        assert len(assistant_msgs) == 1
+        assert [tc.id for tc in assistant_msgs[0].tool_calls] == ["t1", "t2", "t3"]
+        # Verbatim fields (reasoning + extra) carried on the assistant message.
+        assert assistant_msgs[0].reasoning_content == "thinking about the search"
+        assert assistant_msgs[0].reasoning_signature == "sig-abc123"
+        assert assistant_msgs[0].provider_extra == "keep-me"
+        # ALL ToolResults follow, in input order; ERR only in tool content.
+        tool_msgs = [m for m in msgs if getattr(m, "role", None) == "tool"]
+        assert [getattr(m, "tool_call_id", None) for m in tool_msgs] == [
+            "t1",
+            "t2",
+            "t3",
+        ]
+        contents = [getattr(m, "content", "") for m in tool_msgs]
+        assert contents[0] == "result-t1"
+        assert contents[1] == "result-t2"
+        assert any("ERR: Tool calc execution failed" in c for c in contents)
+
     # Pre-execution cancellation (tool returns "Cancelled: ..." on stall)
 
     def test_should_cancel_tool_call_on_repeating_window(self, strategy):

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "amrita-core"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "amrita-core"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2604,8 +2604,8 @@ name = "uvicorn"
 version = "0.52.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }


### PR DESCRIPTION
## Summary by Sourcery

Ensure agent tool-call handling preserves provider reasoning metadata and batches concurrent tool results into a single assistant message per response.

Bug Fixes:
- Preserve reasoning_signature and any provider-specific extra fields on fabricated assistant messages so thinking-mode provider contracts are respected.
- Keep original ToolCall arguments verbatim when tools raise errors, marking failures only via ERR-prefixed ToolResult content.
- Batch multiple concurrent tool_calls from a single response into one assistant message followed by all corresponding ToolResults in call order to satisfy API pairing requirements.

Enhancements:
- Refactor assistant message construction to derive fields generically from provider responses, avoiding hard-coded reasoning metadata handling.
- Introduce optional injection points for tool failure guidance hints that can be customized by strategies.

Build:
- Bump project version from 0.13.2 to 0.13.4.

Documentation:
- Update English and Chinese troubleshooting guides to document the new reasoning metadata round-trip and batched tool-call/result pairing behavior.