### PR TITLE
Move preset fallback to gateways and fail fast on missing default

### DIFF
--- a/docs/docs/guide/api-reference/classes/FallbackContext.md
+++ b/docs/docs/guide/api-reference/classes/FallbackContext.md
@@ -1,6 +1,17 @@
 # FallbackContext
 
-The `FallbackContext` class represents the context for preset fallback events when an LLM request fails.
+The `FallbackContext` class is the **base class** for all preset-fallback events fired by the `libchat` gateway layer (`call_completion`, `tools_caller`, `call_embedding`) when a request fails. It represents the context of a preset fallback event and carries the information needed to switch to an alternative preset.
+
+Every fallback event shares the `PRESET_FALLBACK` event type; concrete subclasses distinguish the failing gateway call so matchers can react differently to each kind.
+
+## Class Hierarchy
+
+```text
+FallbackContext (base)
+├── CompletionFallbackContext  # call_completion fails
+├── ToolsFallbackContext       # tools_caller fails
+└── EmbeddingFallbackContext   # call_embedding fails
+```
 
 ## Constructor
 
@@ -9,7 +20,7 @@ FallbackContext(
     preset: ModelPreset,
     exc_info: BaseException,
     config: AmritaConfig,
-    context: SendMessageWrap,
+    context: SendMessageWrap | CONTENT_LIST_TYPE | Sequence[str],
     term: int
 )
 ```
@@ -24,7 +35,7 @@ FallbackContext(
 ### exc_info
 
 - **Type**: `BaseException`
-- **Description**: The exception that caused the LLM request to fail.
+- **Description**: The exception that caused the request to fail.
 
 ### config
 
@@ -33,13 +44,32 @@ FallbackContext(
 
 ### context
 
-- **Type**: [`SendMessageWrap`](./SendMessageWrap.md)
-- **Description**: The message context that was being sent when the failure occurred.
+- **Type**: `SendMessageWrap | CONTENT_LIST_TYPE | Sequence[str]`
+- **Description**: The payload of the failed call. The concrete type depends on the subclass:
+  - `CompletionFallbackContext`: validated message list (`CONTENT_LIST_TYPE`)
+  - `ToolsFallbackContext`: validated message list (`CONTENT_LIST_TYPE`)
+  - `EmbeddingFallbackContext`: input text sequence (`Sequence[str]`)
 
 ### term
 
 - **Type**: `int`
-- **Description**: The current retry attempt number (starting from 1).
+- **Description**: The current fallback attempt number (starting from 1).
+
+## Subclasses
+
+### CompletionFallbackContext
+
+Fired when `call_completion` fails. `context` carries the validated message list (`CONTENT_LIST_TYPE`).
+
+### ToolsFallbackContext
+
+Fired when `tools_caller` fails. In addition to `context`, it exposes:
+
+- `tools` (`list[ToolFunctionSchema] | None`): the tool schemas of the failed call.
+
+### EmbeddingFallbackContext
+
+Fired when `call_embedding` fails. `context` carries the input text sequence (`Sequence[str]`).
 
 ## Methods
 
@@ -66,7 +96,7 @@ Get the event type enum value.
 ## Example Usage
 
 ```python
-from amrita_core.hook.event import FallbackContext
+from amrita_core.hook.event import CompletionFallbackContext, FallbackContext
 from amrita_core.hook.on import on_preset_fallback
 
 
@@ -79,4 +109,11 @@ async def handle_fallback(event: FallbackContext):
     else:
         # Fail on subsequent retries
         event.fail("No more fallback options")
+
+
+@on_preset_fallback().handle()
+async def handle_tools_fallback(event: ToolsFallbackContext):
+    # Differentiate between fallback kinds
+    print(f"Tool call failed: {event.tools}")
+    event.preset = get_fallback_preset()
 ```

--- a/docs/docs/guide/api-reference/classes/MultiPresetManager.md
+++ b/docs/docs/guide/api-reference/classes/MultiPresetManager.md
@@ -9,7 +9,7 @@ MultiPresetManager stores presets in a name-keyed dict and supports default-pres
 ## Methods
 
 - `set_default_preset(preset: ModelPreset | str) -> None`: Set the default preset (auto-adds if not registered)
-- `get_default_preset() -> ModelPreset`: Get the default preset; falls back to a random preset with a warning if none set
+- `get_default_preset() -> ModelPreset`: Get the default preset; raises `RuntimeError` if none set (fail-fast)
 - `get_preset(name: str) -> ModelPreset`: Get a preset by name; raises `ValueError` if not found
 - `add_preset(preset: ModelPreset) -> None`: Add a preset; raises `ValueError` if the name already exists
 - `get_all_presets() -> list[ModelPreset]`: List all presets

--- a/docs/docs/guide/api-reference/classes/PresetManager.md
+++ b/docs/docs/guide/api-reference/classes/PresetManager.md
@@ -6,7 +6,7 @@ The PresetManager class provides a singleton-based management system for AI mode
 
 **PresetManager is the recommended way to manage model presets in AmritaCore.** Instead of manually creating and handling `ModelPreset` instances, you should use PresetManager to centralize preset management, ensuring consistency and reducing configuration errors.
 
-When no preset is explicitly selected, the system will **automatically fallback to a default preset**. This fallback mechanism ensures your application continues to work even if preset selection fails or is not specified.
+When no default preset has been set via `set_default_preset()`, calling `get_default_preset()` **fails fast** by raising a `RuntimeError`. This explicit behavior surfaces misconfiguration early instead of silently picking an arbitrary preset.
 
 ## Properties
 
@@ -49,7 +49,7 @@ manager.set_default_preset("my-preset-name")
 
 ### `get_default_preset() -> ModelPreset`
 
-Returns the default preset. If no default has been set, it will automatically select a random preset from available presets.
+Returns the default preset set via `set_default_preset()`. If no default has been set, it **fails fast** by raising a `RuntimeError` — call `set_default_preset()` first.
 
 **Returns:**
 
@@ -198,11 +198,11 @@ manager.add_preset(
     )
 )
 
-# Set a default preset (optional, but recommended)
+# Set a default preset (required before get_default_preset())
 manager.set_default_preset("fast")
 
 # Use presets in your application
-# If you don't specify a preset, get_default_preset() will auto-fallback
+# get_default_preset() raises RuntimeError if no default was set
 preset = manager.get_default_preset()  # Returns "fast" preset
 ```
 
@@ -210,7 +210,7 @@ preset = manager.get_default_preset()  # Returns "fast" preset
 
 1. **Centralized Management**: All presets are stored and managed in one place
 2. **Singleton Pattern**: Ensures consistent preset state across your application
-3. **Automatic Fallback**: If no preset is selected, a default is automatically chosen
+3. **Fail-fast**: Calling `get_default_preset()` without setting a default raises `RuntimeError` immediately, surfacing misconfiguration early
 4. **Validation**: Prevents duplicate preset names and validates configurations
 5. **Testing**: Built-in testing capability to verify preset functionality
 6. **Type Safety**: Full type hints for better IDE support and error prevention

--- a/docs/docs/guide/api-reference/index.md
+++ b/docs/docs/guide/api-reference/index.md
@@ -181,10 +181,10 @@ agent = create_agent(
 
 ## Events & Hooks
 
-| Class                                               | Description                                                    |
-| --------------------------------------------------- | -------------------------------------------------------------- |
-| [CompletionEvent](classes/CompletionEvent.md)       | Fired after model completion (event type `COMPLETION`)         |
-| [PreCompletionEvent](classes/PreCompletionEvent.md) | Fired before strategy run and completion (`BEFORE_COMPLETION`) |
+| Class                                               | Description                                                                                                                                              |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [CompletionEvent](classes/CompletionEvent.md)       | Fired after model completion (event type `COMPLETION`)                                                                                                   |
+| [PreCompletionEvent](classes/PreCompletionEvent.md) | Fired before strategy run and completion (`BEFORE_COMPLETION`)                                                                                           |
 | [FallbackContext](classes/FallbackContext.md)       | Base context for preset fallback events (`PRESET_FALLBACK`); subclasses: `CompletionFallbackContext`, `ToolsFallbackContext`, `EmbeddingFallbackContext` |
 
 ## Presets & Tokenizers

--- a/docs/docs/guide/api-reference/index.md
+++ b/docs/docs/guide/api-reference/index.md
@@ -185,7 +185,7 @@ agent = create_agent(
 | --------------------------------------------------- | -------------------------------------------------------------- |
 | [CompletionEvent](classes/CompletionEvent.md)       | Fired after model completion (event type `COMPLETION`)         |
 | [PreCompletionEvent](classes/PreCompletionEvent.md) | Fired before strategy run and completion (`BEFORE_COMPLETION`) |
-| [FallbackContext](classes/FallbackContext.md)       | Context for preset fallback events (`PRESET_FALLBACK`)         |
+| [FallbackContext](classes/FallbackContext.md)       | Base context for preset fallback events (`PRESET_FALLBACK`); subclasses: `CompletionFallbackContext`, `ToolsFallbackContext`, `EmbeddingFallbackContext` |
 
 ## Presets & Tokenizers
 

--- a/docs/docs/zh/guide/api-reference/classes/FallbackContext.md
+++ b/docs/docs/zh/guide/api-reference/classes/FallbackContext.md
@@ -1,6 +1,17 @@
 # FallbackContext
 
-`FallbackContext` 类表示 LLM 请求失败时预设回退事件的上下文。
+`FallbackContext` 类是所有预设回退事件的**基类**，由 `libchat` 网关层（`call_completion`、`tools_caller`、`call_embedding`）在请求失败时触发。它携带切换到备用预设所需的信息。
+
+所有回退事件共享 `PRESET_FALLBACK` 事件类型；具体子类用于区分失败的网关调用，使 matcher 可以对不同类型的回退做出不同响应。
+
+## 类层次
+
+```text
+FallbackContext（基类）
+├── CompletionFallbackContext  # call_completion 失败
+├── ToolsFallbackContext       # tools_caller 失败
+└── EmbeddingFallbackContext   # call_embedding 失败
+```
 
 ## 构造函数
 
@@ -9,7 +20,7 @@ FallbackContext(
     preset: ModelPreset,
     exc_info: BaseException,
     config: AmritaConfig,
-    context: SendMessageWrap,
+    context: SendMessageWrap | CONTENT_LIST_TYPE | Sequence[str],
     term: int
 )
 ```
@@ -24,7 +35,7 @@ FallbackContext(
 ### exc_info
 
 - **类型**：`BaseException`
-- **描述**：导致 LLM 请求失败的异常
+- **描述**：导致请求失败的异常
 
 ### config
 
@@ -33,10 +44,76 @@ FallbackContext(
 
 ### context
 
-- **类型**：[`SendMessageWrap`](./SendMessageWrap.md)
-- **描述**：失败发生时的消息上下文
+- **类型**：`SendMessageWrap | CONTENT_LIST_TYPE | Sequence[str]`
+- **描述**：失败调用的载荷。具体类型取决于子类：
+  - `CompletionFallbackContext`：校验后的消息列表（`CONTENT_LIST_TYPE`）
+  - `ToolsFallbackContext`：校验后的消息列表（`CONTENT_LIST_TYPE`）
+  - `EmbeddingFallbackContext`：输入文本序列（`Sequence[str]`）
 
 ### term
 
 - **类型**：`int`
-- **描述**：当前重试次数
+- **描述**：当前回退尝试次数（从 1 开始）
+
+## 子类
+
+### CompletionFallbackContext
+
+当 `call_completion` 失败时触发。`context` 携带校验后的消息列表（`CONTENT_LIST_TYPE`）。
+
+### ToolsFallbackContext
+
+当 `tools_caller` 失败时触发。除 `context` 外，还暴露：
+
+- `tools`（`list[ToolFunctionSchema] | None`）：失败调用的工具 schema。
+
+### EmbeddingFallbackContext
+
+当 `call_embedding` 失败时触发。`context` 携带输入文本序列（`Sequence[str]`）。
+
+## 方法
+
+### fail(reason: Any | None = None) -> Never
+
+标记事件失败并终止重试流程。
+
+**参数**：
+
+- `reason`（Any | None）：可选的失败原因。
+
+**抛出**：
+
+- [`FallbackFailed`](../exceptions/FallbackFailed.md)：总是抛出此异常以终止回退流程。
+
+### get_event_type() -> EventTypeEnum
+
+获取事件类型枚举值。
+
+**返回**：
+
+- `EventTypeEnum.PRESET_FALLBACK`
+
+## 使用示例
+
+```python
+from amrita_core.hook.event import CompletionFallbackContext, FallbackContext
+from amrita_core.hook.on import on_preset_fallback
+
+
+@on_preset_fallback().handle()
+async def handle_fallback(event: FallbackContext):
+    print(f"Request failed: {event.exc_info}")
+    if event.term == 1:
+        # 首次重试时切换到备用预设
+        event.preset = get_alternative_preset()
+    else:
+        # 后续重试直接失败
+        event.fail("No more fallback options")
+
+
+@on_preset_fallback().handle()
+async def handle_tools_fallback(event: ToolsFallbackContext):
+    # 区分不同类型的回退
+    print(f"Tool call failed: {event.tools}")
+    event.preset = get_fallback_preset()
+```

--- a/docs/docs/zh/guide/api-reference/classes/MultiPresetManager.md
+++ b/docs/docs/zh/guide/api-reference/classes/MultiPresetManager.md
@@ -9,7 +9,7 @@ MultiPresetManager 将预设存储在按名称索引的字典中，支持默认�
 ## 方法
 
 - `set_default_preset(preset: ModelPreset | str) -> None`：设置默认预设（未注册则自动添加）
-- `get_default_preset() -> ModelPreset`：获取默认预设；未设置则随机返回一个并发出警告
+- `get_default_preset() -> ModelPreset`：获取默认预设；未设置则引发 `RuntimeError`（快速失败）
 - `get_preset(name: str) -> ModelPreset`：按名称获取预设；未找到则引发 `ValueError`
 - `add_preset(preset: ModelPreset) -> None`：添加预设；名称已存在则引发 `ValueError`
 - `get_all_presets() -> list[ModelPreset]`：列出所有预设

--- a/docs/docs/zh/guide/api-reference/classes/PresetManager.md
+++ b/docs/docs/zh/guide/api-reference/classes/PresetManager.md
@@ -26,4 +26,4 @@ manager.set_default_preset("my-preset-name")
 
 ### `get_default_preset() -> ModelPreset`
 
-获取默认预设。
+获取默认预设。若未通过 `set_default_preset()` 设置，则直接引发 `RuntimeError`（快速失败），需先调用 `set_default_preset()`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.13.5"
+version = "0.13.6"
 description = "High performance, flexible, lightweight agent framework."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/readmes/EN_US.md
+++ b/readmes/EN_US.md
@@ -129,7 +129,7 @@ Comprehensive event-driven architecture with multiple hook points:
 
 - **PreCompletionEvent**: Modify messages before sending to LLM
 - **CompletionEvent**: Process responses after receiving from LLM
-- **FallbackContext**: Handle LLM request failures with automatic retry logic
+- **FallbackContext**: Handle LLM request failures with automatic retry logic (subclasses: `CompletionFallbackContext`, `ToolsFallbackContext`, `EmbeddingFallbackContext`)
 - **Custom Events**: Extensible event system for custom integrations
 
 ### Tool System

--- a/readmes/ZH_CN.md
+++ b/readmes/ZH_CN.md
@@ -129,7 +129,7 @@ AmritaCore 通过协议适配器支持多个LLM提供商：
 
 - **PreCompletionEvent**: 在向LLM发送前修改消息
 - **CompletionEvent**: 在从LLM接收后处理响应
-- **FallbackContext**: 处理LLM请求失败，具有自动重试逻辑
+- **FallbackContext**: 处理LLM请求失败，具有自动重试逻辑（子类：`CompletionFallbackContext`、`ToolsFallbackContext`、`EmbeddingFallbackContext`）
 - **自定义事件**: 用于自定义集成的可扩展事件系统
 
 ### 工具系统

--- a/src/amrita_core/__init__.py
+++ b/src/amrita_core/__init__.py
@@ -57,7 +57,14 @@ from .builtins.backends import LegacyBackend
 from .chatmanager import ChatManager, ChatObject, ChatObjectMeta, SuspendEnum
 from .config import AmritaConfig, get_config, set_config
 from .contexts import AbilityContext, StateContext
-from .hook.event import CompletionEvent, EventTypeEnum, PreCompletionEvent
+from .hook.event import (
+    CompletionEvent,
+    CompletionFallbackContext,
+    EmbeddingFallbackContext,
+    EventTypeEnum,
+    PreCompletionEvent,
+    ToolsFallbackContext,
+)
 from .hook.on import on_completion, on_event, on_precompletion
 from .libchat import (
     call_completion,
@@ -126,6 +133,8 @@ __all__ = [
     "ChatObject",
     "ChatObjectMeta",
     "CompletionEvent",
+    "CompletionFallbackContext",
+    "EmbeddingFallbackContext",
     "EventTypeEnum",
     "Function",
     "FunctionDefinitionSchema",
@@ -148,6 +157,7 @@ __all__ = [
     "ToolData",
     "ToolFunctionSchema",
     "ToolResult",
+    "ToolsFallbackContext",
     "ToolsManager",
     "UniResponse",
     "UniResponseUsage",

--- a/src/amrita_core/components/llm.py
+++ b/src/amrita_core/components/llm.py
@@ -11,7 +11,6 @@ graph LR
 import asyncio
 
 from amrita_sense import Node, WorkflowInterpreter
-from amrita_sense.hook.matcher import MatcherFactory
 from amrita_sense.logging import debug_log, logger
 
 from amrita_core.base.adapter import MessageContent
@@ -23,8 +22,6 @@ from amrita_core.contexts import (
     WorkingState,
 )
 from amrita_core.enums import SuspendEnum
-from amrita_core.hook.event import FallbackContext
-from amrita_core.hook.exception import FallbackFailed
 from amrita_core.libchat import call_completion
 from amrita_core.types.message import Message
 from amrita_core.types.response import UniResponse
@@ -88,22 +85,18 @@ async def LLM_COMPLETION(
     intp: WorkflowInterpreter,
     resp: RespState,
 ):
-    """Call the LLM completion API with preset fallback and retry logic.
+    """Call the LLM completion API and stream chunks to the client.
 
     ```mermaid
     flowchart TD
-        A[Current Preset] --> B[call_completion stream]
-        B -->|success| C[resp.response = UniResponse]
-        B -->|exception| D[Fire FallbackContext hook]
-        D --> E{New preset available?}
-        E -->|yes| F[Switch preset & retry]
-        F --> A
-        E -->|no| G[FallbackFailed]
+        A[call_completion gateway] --> B[stream chunks]
+        B -->|UniResponse| C[resp.response = UniResponse]
+        B -->|text chunk| D[yield to client]
     ```
 
-    Streams chunks via `WorkflowInterpreter.object_io`. On failure, fires the
-    `FallbackContext` event hook to try alternate presets, up to
-    `max_fallbacks` times.
+    Preset fallback is handled inside the ``call_completion`` gateway (it
+    fires ``CompletionFallbackContext`` on failure), so this node only consumes
+    the stream and forwards the final ``UniResponse``.
 
     Context Dependencies:
         * AbilityState — provides config and current preset.
@@ -123,41 +116,21 @@ async def LLM_COMPLETION(
     """
     logger.debug("Calling chat model..")
     response: UniResponse[str, None] | None = None
-    used_preset: set[str] = set()
     assert wok.context_wrap is not None, (
         "Context wrap is not set, please run `BUILD_MESSAGE` before commit"
     )
     assert ability.preset is not None, (
         "Preset is not set, please run `LOAD_STATE` before calling LLM"
     )
-    for i in range(1, ability.config.llm.max_fallbacks + 1):
-        try:
-            used_preset.add(ability.preset.name)
-            async for chunk in call_completion(
-                wok.context_wrap.unwrap(),
-                config=ability.config,
-                preset=ability.preset,
-            ):
-                if isinstance(chunk, UniResponse):
-                    response = chunk
-                elif isinstance(chunk, MessageContent | str):
-                    await intp.object_io.yield_response(chunk)
-            break
-        except Exception as e:
-            logger.warning(
-                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{ability.config.llm.max_retries})..."
-            )
-            ctx = FallbackContext(
-                ability.preset, e, ability.config, wok.context_wrap, i
-            )
-            await MatcherFactory.trigger_event(
-                ctx, ctx.config, exception_ignored=(FallbackFailed,)
-            )
-            if ctx.preset is ability.preset:
-                ctx.fail("No preset fallback available, exiting!")
-            ability.preset = ctx.preset
-    else:
-        raise FallbackFailed("Max preset fallbacks retries exceeded.")
+    async for chunk in call_completion(
+        wok.context_wrap.unwrap(),
+        config=ability.config,
+        preset=ability.preset,
+    ):
+        if isinstance(chunk, UniResponse):
+            response = chunk
+        elif isinstance(chunk, MessageContent | str):
+            await intp.object_io.yield_response(chunk)
     if response is None:
         raise RuntimeError("No final response from chat adapter.")
     resp.response = response

--- a/src/amrita_core/hook/event.py
+++ b/src/amrita_core/hook/event.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -8,11 +9,17 @@ from amrita_sense.hook.event import BaseEvent
 from typing_extensions import Never, override
 
 from amrita_core.hook.exception import FallbackFailed
-from amrita_core.types import USER_INPUT, ModelPreset, SendMessageWrap
+from amrita_core.types import (
+    CONTENT_LIST_TYPE,
+    USER_INPUT,
+    ModelPreset,
+    SendMessageWrap,
+)
 
 if TYPE_CHECKING:
     from amrita_core.chatmanager import ChatObject
     from amrita_core.config import AmritaConfig
+    from amrita_core.tools.models import ToolFunctionSchema
 
 
 class EventTypeEnum(str, Enum):
@@ -35,10 +42,17 @@ class EventTypeEnum(str, Enum):
 
 @dataclass
 class FallbackContext(BaseEvent[EventTypeEnum]):
+    """Base event for all preset-fallback events.
+
+    Every fallback event shares the ``PRESET_FALLBACK`` event type; concrete
+    subclasses distinguish the failing gateway call (completion / tools /
+    embedding) so matchers can react differently to each kind.
+    """
+
     preset: ModelPreset
     exc_info: BaseException
     config: "AmritaConfig"
-    context: SendMessageWrap
+    context: SendMessageWrap | CONTENT_LIST_TYPE | Sequence[str]
     term: int
 
     def __post_init__(self):
@@ -54,6 +68,33 @@ class FallbackContext(BaseEvent[EventTypeEnum]):
     def fail(self, reason: Any | None = None) -> Never:  # pragma: no cover
         """Mark the event as failed"""
         raise FallbackFailed(reason)
+
+
+@dataclass
+class CompletionFallbackContext(FallbackContext):
+    """Fallback event fired when ``call_completion`` fails.
+
+    ``context`` carries the validated message list (``CONTENT_LIST_TYPE``).
+    """
+
+
+@dataclass
+class ToolsFallbackContext(FallbackContext):
+    """Fallback event fired when ``tools_caller`` fails.
+
+    ``context`` carries the validated message list (``CONTENT_LIST_TYPE``);
+    ``tools`` carries the tool schemas of the failed call.
+    """
+
+    tools: list[ToolFunctionSchema] | None = None
+
+
+@dataclass
+class EmbeddingFallbackContext(FallbackContext):
+    """Fallback event fired when ``call_embedding`` fails.
+
+    ``context`` carries the input text sequence (``Sequence[str]``).
+    """
 
 
 @dataclass
@@ -135,8 +176,11 @@ class PreCompletionEvent(Event):
 __all__ = [
     "BaseEvent",  # For backward compatibility
     "CompletionEvent",
+    "CompletionFallbackContext",
+    "EmbeddingFallbackContext",
     "Event",
     "EventTypeEnum",
     "FallbackContext",
     "PreCompletionEvent",
+    "ToolsFallbackContext",
 ]

--- a/src/amrita_core/hook/event.py
+++ b/src/amrita_core/hook/event.py
@@ -74,7 +74,8 @@ class FallbackContext(BaseEvent[EventTypeEnum]):
 class CompletionFallbackContext(FallbackContext):
     """Fallback event fired when ``call_completion`` fails.
 
-    ``context`` carries the validated message list (``CONTENT_LIST_TYPE``).
+    ``context`` carries the message list passed to ``call_completion``
+    (may be raw/unvalidated depending on caller configuration).
     """
 
 
@@ -82,7 +83,8 @@ class CompletionFallbackContext(FallbackContext):
 class ToolsFallbackContext(FallbackContext):
     """Fallback event fired when ``tools_caller`` fails.
 
-    ``context`` carries the validated message list (``CONTENT_LIST_TYPE``);
+    ``context`` carries the message list passed to ``tools_caller``
+    (may be raw/unvalidated depending on caller configuration);
     ``tools`` carries the tool schemas of the failed call.
     """
 

--- a/src/amrita_core/libchat.py
+++ b/src/amrita_core/libchat.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import AsyncGenerator, Callable, Generator, Sequence
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Sequence
 from io import StringIO
 
-from amrita_sense.logging import debug_log
+from amrita_sense.hook.matcher import MatcherFactory
+from amrita_sense.logging import debug_log, logger
 from amrita_sense.streaming import SuspendObjectStream
 from pydantic import ValidationError
 
@@ -14,6 +15,13 @@ from amrita_core.base.adapter import (
     MessageContent,
     ModelAdapter,
 )
+from amrita_core.hook.event import (
+    CompletionFallbackContext,
+    EmbeddingFallbackContext,
+    FallbackContext,
+    ToolsFallbackContext,
+)
+from amrita_core.hook.exception import FallbackFailed
 from amrita_core.preset import PresetManager
 from amrita_core.usage import SessionUsageProxy
 from amrita_core.utils import _did_you_mean_hint
@@ -321,6 +329,71 @@ async def _call_with_reflection(
     return await call_func(adapter)
 
 
+async def _fire_fallback(
+    preset: ModelPreset,
+    exc: BaseException,
+    config: AmritaConfig,
+    term: int,
+    ctx_factory: Callable[[ModelPreset, BaseException, int], FallbackContext],
+) -> ModelPreset:
+    """Fire a ``PRESET_FALLBACK`` event and resolve the replacement preset.
+
+    Matchers registered via ``@on_preset_fallback()`` may swap ``ctx.preset``
+    to retry with an alternative preset.  When no matcher replaces it (or no
+    matcher is registered at all), ``FallbackFailed`` is raised.
+
+    Args:
+        preset: The preset that just failed.
+        exc: The exception that caused the failure.
+        config: Config providing ``llm.max_fallbacks`` / ``llm.max_retries``.
+        term: Current attempt number (starting from 1).
+        ctx_factory: Builds the concrete ``FallbackContext`` subclass for the
+            failing gateway call (completion / tools / embedding).
+
+    Returns:
+        The replacement preset chosen by the matcher.
+    """
+    ctx = ctx_factory(preset, exc, term)
+    await MatcherFactory.trigger_event(
+        ctx, ctx.config, exception_ignored=(FallbackFailed,)
+    )
+    if ctx.preset is preset:
+        ctx.fail("No preset fallback available, exiting!")
+    return ctx.preset
+
+
+async def _with_preset_fallback(
+    preset: ModelPreset,
+    config: AmritaConfig,
+    ctx_factory: Callable[[ModelPreset, BaseException, int], FallbackContext],
+    attempt: Callable[[ModelPreset], Awaitable[T]],
+) -> T:
+    """Run an adapter call wrapped in the gateway preset-fallback loop.
+
+    Args:
+        preset: Initial preset to try.
+        config: Config providing ``llm.max_fallbacks``.
+        ctx_factory: Builds the concrete ``FallbackContext`` subclass.
+        attempt: Coroutine performing one call with the given preset.
+
+    Returns:
+        The result of the first successful attempt.
+
+    Raises:
+        FallbackFailed: When no preset fallback is available or every attempt
+            fails.
+    """
+    for i in range(1, config.llm.max_fallbacks + 1):
+        try:
+            return await attempt(preset)
+        except Exception as e:  # noqa: PERF203 -- fallback loop must retry on failure
+            logger.warning(
+                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{config.llm.max_retries})..."
+            )
+            preset = await _fire_fallback(preset, e, config, i, ctx_factory)
+    raise FallbackFailed("Max preset fallbacks retries exceeded.")
+
+
 async def tools_caller(
     messages: CONTENT_LIST_TYPE,
     tools: list[ToolFunctionSchema],
@@ -344,26 +417,33 @@ async def tools_caller(
         Response containing tool calls or None
     """
     config = config or get_config()
-
-    async def _call_tools(
-        adapter: ModelAdapter,
-    ):
-        return await adapter.call_tools(messages, tools, tool_choice)
-
     preset = preset or PresetManager().get_default_preset()
-    _validate_msg_list(messages, thinking_config=preset.thinking_config)
-    resp = await _call_with_reflection(
+
+    async def _attempt(
+        current_preset: ModelPreset,
+    ) -> UniResponse[None, list[ToolCall] | None]:
+        _validate_msg_list(messages, thinking_config=current_preset.thinking_config)
+
+        async def _call_tools(
+            adapter: ModelAdapter,
+        ):
+            return await adapter.call_tools(messages, tools, tool_choice)
+
+        resp = await _call_with_reflection(current_preset, _call_tools, config)
+        if usage is not None and resp.usage is not None:
+            usage.record(
+                resp.usage,
+                model=resp.metadata.model,
+                request_id=resp.metadata.original_request_id,
+            )
+        return resp
+
+    return await _with_preset_fallback(
         preset,
-        _call_tools,
         config,
+        lambda p, e, i: ToolsFallbackContext(p, e, config, messages, i, tools=tools),
+        _attempt,
     )
-    if usage is not None and resp.usage is not None:
-        usage.record(
-            resp.usage,
-            model=resp.metadata.model,
-            request_id=resp.metadata.original_request_id,
-        )
-    return resp
 
 
 async def call_completion(
@@ -387,40 +467,72 @@ async def call_completion(
     """
     preset = preset or PresetManager().get_default_preset()
     config = config or get_config()
-    messages = _validate_msg_list(messages, thinking_config=preset.thinking_config)
 
-    async def _call_api(
-        adapter: ModelAdapter,
-    ) -> Callable[
-        [], AsyncGenerator[MessageContent | str | UniResponse[str, None], typing.Any]
-    ]:
-        if "text-gen" != adapter.get_type() and "text-gen" not in adapter.get_type():
-            raise ValueError(
-                f"Model adapter {adapter.get_type()} does not support text-gen"
+    async def _attempt(
+        current_preset: ModelPreset,
+    ) -> AsyncGenerator[COMPLETION_RETURNING, None]:
+        validated = _validate_msg_list(
+            messages, thinking_config=current_preset.thinking_config
+        )
+
+        async def _call_api(
+            adapter: ModelAdapter,
+        ) -> Callable[
+            [],
+            AsyncGenerator[MessageContent | str | UniResponse[str, None], typing.Any],
+        ]:
+            if (
+                "text-gen" != adapter.get_type()
+                and "text-gen" not in adapter.get_type()
+            ):
+                raise ValueError(
+                    f"Model adapter {adapter.get_type()} does not support text-gen"
+                )
+            return lambda: adapter.call_api(
+                [(i.model_dump()) for i in validated], **kwargs
             )
-        return lambda: adapter.call_api([(i.model_dump()) for i in messages], **kwargs)
 
-    # Call adapter to get chat response
-    response = await _call_with_reflection(preset, _call_api, config)
-    is_thinking = False
-    async for resp in response():
-        if preset.config.cot_model:
-            if isinstance(resp, str):
-                if "<think>" in resp:
-                    is_thinking = True
-                    continue
-                elif "</think>" in resp:
-                    is_thinking = False
-                    continue
-        if not is_thinking:
-            if isinstance(resp, UniResponse) and usage is not None:
-                if resp.usage is not None:
-                    usage.record(
-                        resp.usage,
-                        model=resp.metadata.model,
-                        request_id=resp.metadata.original_request_id,
-                    )
-            yield resp
+        # Call adapter to get chat response
+        response = await _call_with_reflection(current_preset, _call_api, config)
+        is_thinking = False
+        async for resp in response():
+            if current_preset.config.cot_model:
+                if isinstance(resp, str):
+                    if "<think>" in resp:
+                        is_thinking = True
+                        continue
+                    elif "</think>" in resp:
+                        is_thinking = False
+                        continue
+            if not is_thinking:
+                if isinstance(resp, UniResponse) and usage is not None:
+                    if resp.usage is not None:
+                        usage.record(
+                            resp.usage,
+                            model=resp.metadata.model,
+                            request_id=resp.metadata.original_request_id,
+                        )
+                yield resp
+
+    for i in range(1, config.llm.max_fallbacks + 1):
+        try:
+            async for chunk in _attempt(preset):
+                yield chunk
+            return
+        except Exception as e:  # noqa: PERF203 -- fallback loop must retry the stream on failure
+            logger.warning(
+                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{config.llm.max_retries})..."
+            )
+            preset = await _fire_fallback(
+                preset,
+                e,
+                config,
+                i,
+                lambda p, exc, term: CompletionFallbackContext(
+                    p, exc, config, messages, term
+                ),
+            )
+    raise FallbackFailed("Max preset fallbacks retries exceeded.")
 
 
 async def get_last_response(
@@ -463,17 +575,27 @@ async def call_embedding(
     if isinstance(text, str):
         raise TypeError("Text must be a sequence of strings, not a single string.")
 
-    async def _call_embed(
-        adapter: ModelAdapter,
+    async def _attempt(
+        current_preset: ModelPreset,
     ) -> Sequence[EmbeddingChunk]:
-        if "embed" != adapter.get_type() and "embed" not in adapter.get_type():
-            raise ValueError(
-                f"Model adapter {adapter.get_type()} does not support embedding"
-            )
-        return await adapter.call_embed(text, **kwargs)
+        async def _call_embed(
+            adapter: ModelAdapter,
+        ) -> Sequence[EmbeddingChunk]:
+            if "embed" != adapter.get_type() and "embed" not in adapter.get_type():
+                raise ValueError(
+                    f"Model adapter {adapter.get_type()} does not support embedding"
+                )
+            return await adapter.call_embed(text, **kwargs)
 
-    return await _call_with_reflection(
+        return await _call_with_reflection(
+            current_preset,
+            _call_embed,
+            config,
+        )
+
+    return await _with_preset_fallback(
         preset,
-        _call_embed,
         config,
+        lambda p, e, i: EmbeddingFallbackContext(p, e, config, text, i),
+        _attempt,
     )

--- a/src/amrita_core/libchat.py
+++ b/src/amrita_core/libchat.py
@@ -388,7 +388,7 @@ async def _with_preset_fallback(
             return await attempt(preset)
         except Exception as e:  # noqa: PERF203 -- fallback loop must retry on failure
             logger.warning(
-                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{config.llm.max_retries})..."
+                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{config.llm.max_fallbacks})..."
             )
             preset = await _fire_fallback(preset, e, config, i, ctx_factory)
     raise FallbackFailed("Max preset fallbacks retries exceeded.")
@@ -521,7 +521,7 @@ async def call_completion(
             return
         except Exception as e:  # noqa: PERF203 -- fallback loop must retry the stream on failure
             logger.warning(
-                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{config.llm.max_retries})..."
+                f"Because of `{e!s}`, LLM request failed, retrying ({i}/{config.llm.max_fallbacks})..."
             )
             preset = await _fire_fallback(
                 preset,

--- a/src/amrita_core/preset.py
+++ b/src/amrita_core/preset.py
@@ -1,8 +1,7 @@
-import random
 import time
 import typing
 
-from amrita_sense.logging import debug_log, logger
+from amrita_sense.logging import debug_log
 from typing_extensions import Self
 
 from amrita_core.base.adapter import AdapterManager
@@ -65,8 +64,9 @@ class MultiPresetManager:
         Get the default preset.
         """
         if self._default_preset is None:
-            logger.warning("No default preset set, fall back to a random preset")
-            self._default_preset = random.choice(list(self._presets.values()))
+            raise RuntimeError(
+                "Default preset not set, use set_default_preset() first."
+            )
         return self._default_preset
 
     def get_preset(self, name: str) -> ModelPreset:

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -98,6 +98,7 @@ def _make_ability_context() -> AbilityContext:
         pm.add_preset(ModelPreset(model="gpt-3.5", name="cov-gap-default", api_key="k"))
     except ValueError:
         pass  # already registered from previous test
+    pm.set_default_preset("cov-gap-default")
     return AbilityContext(presets=pm)
 
 

--- a/tests/test_fallback_gateway.py
+++ b/tests/test_fallback_gateway.py
@@ -1,0 +1,281 @@
+"""Tests for the gateway-level preset fallback in ``amrita_core.libchat``.
+
+The fallback loop lives in the gateway functions (``call_completion`` /
+``tools_caller`` / ``call_embedding``) rather than in the ``LLM_COMPLETION``
+workflow node.  On failure each gateway call fires a concrete
+``FallbackContext`` subclass (``CompletionFallbackContext`` /
+``ToolsFallbackContext`` / ``EmbeddingFallbackContext``); a matcher may swap
+``event.preset`` to retry with an alternative preset.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from amrita_sense.hook.matcher import Matcher
+
+from amrita_core.config import AmritaConfig
+from amrita_core.hook.event import (
+    CompletionFallbackContext,
+    EmbeddingFallbackContext,
+    FallbackContext,
+    ToolsFallbackContext,
+)
+from amrita_core.hook.exception import FallbackFailed
+from amrita_core.libchat import call_completion, call_embedding, tools_caller
+from amrita_core.tools.models import ToolFunctionSchema
+from amrita_core.types import Message, ModelPreset, UniResponse
+
+
+def _make_preset(name: str) -> ModelPreset:
+    return ModelPreset(
+        model=f"model-{name}",
+        name=name,
+        api_key="test-key",
+        protocol="test-protocol",
+    )
+
+
+def _make_tools() -> list[ToolFunctionSchema]:
+    return [
+        ToolFunctionSchema.model_validate(
+            {
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather info",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            }
+        )
+    ]
+
+
+@pytest.fixture
+def config() -> AmritaConfig:
+    return AmritaConfig()
+
+
+@pytest.fixture
+def preset_a() -> ModelPreset:
+    return _make_preset("preset-a")
+
+
+@pytest.fixture
+def preset_b() -> ModelPreset:
+    return _make_preset("preset-b")
+
+
+def _expire(matcher: Matcher) -> None:
+    matcher._dead_at = datetime.now() - timedelta(minutes=1)
+
+
+class TestCompletionFallback:
+    """Fallback inside the ``call_completion`` gateway (async generator)."""
+
+    @pytest.mark.asyncio
+    async def test_switches_preset_and_retries(self, config, preset_a, preset_b):
+        """First attempt fails; matcher swaps preset; second attempt succeeds."""
+        matcher = Matcher("PRESET_FALLBACK", priority=1)
+
+        async def switch_preset(ev: FallbackContext):
+            assert isinstance(ev, CompletionFallbackContext)
+            ev.preset = preset_b
+
+        matcher.handle()(switch_preset)
+        try:
+            async def ok_stream():
+                yield "Hello"
+                yield UniResponse(content="Hello", tool_calls=[], usage=None)
+
+            side_effect = [RuntimeError("boom"), lambda: ok_stream()]
+
+            with patch(
+                "amrita_core.libchat._call_with_reflection",
+                side_effect=side_effect,
+            ) as mock_call:
+                chunks = []
+                async for chunk in call_completion(
+                    [Message(role="user", content="Hi")], preset_a, config
+                ):
+                    chunks.append(chunk)
+
+            assert chunks[0] == "Hello"
+            assert isinstance(chunks[-1], UniResponse)
+            assert mock_call.call_count == 2
+            # The second attempt used the replacement preset.
+            assert mock_call.call_args_list[1].args[0] is preset_b
+        finally:
+            _expire(matcher)
+
+    @pytest.mark.asyncio
+    async def test_no_matcher_raises_fallback_failed(self, config, preset_a):
+        """Without a matcher swapping the preset, FallbackFailed is raised."""
+        with patch(
+            "amrita_core.libchat._call_with_reflection",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(FallbackFailed, match="No preset fallback"):
+                async for _ in call_completion(
+                    [Message(role="user", content="Hi")], preset_a, config
+                ):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_exhausted_attempts_raise_fallback_failed(self, config, preset_a, preset_b):
+        """Swapping presets but never succeeding exhausts max_fallbacks."""
+        matcher = Matcher("PRESET_FALLBACK", priority=1)
+
+        async def keep_swapping(ev: FallbackContext):
+            # Always provide a *new* preset object so the loop keeps retrying
+            # until max_fallbacks is exhausted.
+            ev.preset = _make_preset(f"alt-{ev.term}")
+
+        matcher.handle()(keep_swapping)
+        try:
+            with patch(
+                "amrita_core.libchat._call_with_reflection",
+                side_effect=RuntimeError("boom"),
+            ) as mock_call:
+                with pytest.raises(FallbackFailed, match="Max preset fallbacks"):
+                    async for _ in call_completion(
+                        [Message(role="user", content="Hi")], preset_a, config
+                    ):
+                        pass
+                # initial + max_fallbacks retries all failed
+                assert mock_call.call_count == config.llm.max_fallbacks
+        finally:
+            _expire(matcher)
+
+
+class TestToolsFallback:
+    """Fallback inside the ``tools_caller`` gateway."""
+
+    @pytest.mark.asyncio
+    async def test_switches_preset_and_retries(self, config, preset_a, preset_b):
+        matcher = Matcher("PRESET_FALLBACK", priority=1)
+
+        async def switch_preset(ev: FallbackContext):
+            assert isinstance(ev, ToolsFallbackContext)
+            assert ev.tools is not None
+            assert ev.tools[0].function.name == "get_weather"
+            ev.preset = preset_b
+
+        matcher.handle()(switch_preset)
+        try:
+            ok_resp = UniResponse(content=None, tool_calls=[], usage=None)
+
+            with patch(
+                "amrita_core.libchat._call_with_reflection",
+                side_effect=[RuntimeError("boom"), ok_resp],
+            ) as mock_call:
+                result = await tools_caller(
+                    [Message(role="user", content="Weather?")],
+                    _make_tools(),
+                    preset_a,
+                    config=config,
+                )
+
+            assert result is ok_resp
+            assert mock_call.call_count == 2
+            assert mock_call.call_args_list[1].args[0] is preset_b
+        finally:
+            _expire(matcher)
+
+    @pytest.mark.asyncio
+    async def test_no_matcher_raises_fallback_failed(self, config, preset_a):
+        with patch(
+            "amrita_core.libchat._call_with_reflection",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(FallbackFailed, match="No preset fallback"):
+                await tools_caller(
+                    [Message(role="user", content="Weather?")],
+                    _make_tools(),
+                    preset_a,
+                    config=config,
+                )
+
+
+class TestEmbeddingFallback:
+    """Fallback inside the ``call_embedding`` gateway."""
+
+    @pytest.mark.asyncio
+    async def test_switches_preset_and_retries(self, config, preset_a, preset_b):
+        matcher = Matcher("PRESET_FALLBACK", priority=1)
+
+        async def switch_preset(ev: FallbackContext):
+            assert isinstance(ev, EmbeddingFallbackContext)
+            ev.preset = preset_b
+
+        matcher.handle()(switch_preset)
+        try:
+            ok_result = [0.1, 0.2, 0.3]
+
+            with patch(
+                "amrita_core.libchat._call_with_reflection",
+                side_effect=[RuntimeError("boom"), ok_result],
+            ) as mock_call:
+                result = await call_embedding(
+                    ["hello world"], preset_a, config
+                )
+
+            assert result == ok_result
+            assert mock_call.call_count == 2
+            assert mock_call.call_args_list[1].args[0] is preset_b
+        finally:
+            _expire(matcher)
+
+    @pytest.mark.asyncio
+    async def test_no_matcher_raises_fallback_failed(self, config, preset_a):
+        with patch(
+            "amrita_core.libchat._call_with_reflection",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(FallbackFailed, match="No preset fallback"):
+                await call_embedding(["hello world"], preset_a, config)
+
+    @pytest.mark.asyncio
+    async def test_single_string_rejected(self, config, preset_a):
+        with pytest.raises(TypeError, match="sequence of strings"):
+            await call_embedding("hello", preset_a, config)  # type: ignore[arg-type]
+
+
+class TestFallbackEventTypes:
+    """The concrete events share PRESET_FALLBACK but stay distinguishable."""
+
+    @pytest.mark.asyncio
+    async def test_event_hierarchy(self, config, preset_a):
+        from amrita_core.hook.event import EventTypeEnum
+
+        ctx_completion = CompletionFallbackContext(
+            preset_a, RuntimeError("x"), config, [], 1
+        )
+        ctx_tools = ToolsFallbackContext(
+            preset_a, RuntimeError("x"), config, [], 1, tools=_make_tools()
+        )
+        ctx_embedding = EmbeddingFallbackContext(
+            preset_a, RuntimeError("x"), config, ["text"], 1
+        )
+
+        for ctx in (ctx_completion, ctx_tools, ctx_embedding):
+            assert isinstance(ctx, FallbackContext)
+            assert ctx.get_event_type() is EventTypeEnum.PRESET_FALLBACK
+
+        assert not isinstance(ctx_completion, ToolsFallbackContext)
+        assert not isinstance(ctx_tools, EmbeddingFallbackContext)
+        assert ctx_tools.tools is not None
+        assert ctx_embedding.context == ["text"]
+
+    def test_fail_raises_fallback_failed(self, config, preset_a):
+        ctx = CompletionFallbackContext(
+            preset_a, RuntimeError("x"), config, [], 1
+        )
+        with pytest.raises(FallbackFailed):
+            ctx.fail("no fallback")
+
+
+class TestFallbackFailedException:
+    """FallbackFailed is a RuntimeError subclass for broad exception handling."""
+
+    def test_is_runtime_error(self):
+        assert issubclass(FallbackFailed, RuntimeError)

--- a/tests/test_fallback_gateway.py
+++ b/tests/test_fallback_gateway.py
@@ -83,6 +83,7 @@ class TestCompletionFallback:
 
         matcher.handle()(switch_preset)
         try:
+
             async def ok_stream():
                 yield "Hello"
                 yield UniResponse(content="Hello", tool_calls=[], usage=None)
@@ -121,7 +122,9 @@ class TestCompletionFallback:
                     pass
 
     @pytest.mark.asyncio
-    async def test_exhausted_attempts_raise_fallback_failed(self, config, preset_a, preset_b):
+    async def test_exhausted_attempts_raise_fallback_failed(
+        self, config, preset_a, preset_b
+    ):
         """Swapping presets but never succeeding exhausts max_fallbacks."""
         matcher = Matcher("PRESET_FALLBACK", priority=1)
 
@@ -215,9 +218,7 @@ class TestEmbeddingFallback:
                 "amrita_core.libchat._call_with_reflection",
                 side_effect=[RuntimeError("boom"), ok_result],
             ) as mock_call:
-                result = await call_embedding(
-                    ["hello world"], preset_a, config
-                )
+                result = await call_embedding(["hello world"], preset_a, config)
 
             assert result == ok_result
             assert mock_call.call_count == 2
@@ -267,9 +268,7 @@ class TestFallbackEventTypes:
         assert ctx_embedding.context == ["text"]
 
     def test_fail_raises_fallback_failed(self, config, preset_a):
-        ctx = CompletionFallbackContext(
-            preset_a, RuntimeError("x"), config, [], 1
-        )
+        ctx = CompletionFallbackContext(preset_a, RuntimeError("x"), config, [], 1)
         with pytest.raises(FallbackFailed):
             ctx.fail("no fallback")
 

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -143,18 +143,17 @@ class TestMultiPresetManager:
         result = manager.get_default_preset()
         assert result == preset
 
-    def test_get_default_preset_random_choice(self):
-        """Test getting default preset chooses randomly when none set"""
+    def test_get_default_preset_fail_fast(self):
+        """Test getting default preset raises RuntimeError when none set"""
         manager = MultiPresetManager()
-        preset1 = create_test_preset("random1")
-        preset2 = create_test_preset("random2")
+        preset1 = create_test_preset("failfast1")
+        preset2 = create_test_preset("failfast2")
         manager.add_preset(preset1)
         manager.add_preset(preset2)
 
-        # Should pick one of the existing presets
-        result = manager.get_default_preset()
-        assert result in [preset1, preset2]
-        assert manager._default_preset == result
+        # Should fail fast instead of falling back to a random preset
+        with pytest.raises(RuntimeError, match="Default preset not set"):
+            manager.get_default_preset()
 
 
 class TestPresetManagerSingleton:

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" } },
+    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -39,7 +39,7 @@ resolution-markers = [
     "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
 ]
 dependencies = [
-    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/31/edb06aabd8f8f0b56d659f30800795f40b93cba96be946ce179f6931e3a5/aiofile-3.12.3.tar.gz", hash = "sha256:caa6aa746b5e47e2165f7abd741b6415e49cf4d44fddc0f61844612cc3924d41", size = 21600, upload-time = "2026-08-04T22:59:27.171Z" }
 wheels = [
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "amrita-core"
-version = "0.13.4"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1023,8 +1023,8 @@ name = "httpcore2"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -1101,7 +1101,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "(python_full_version < '3.14' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2451,8 +2451,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary by Sourcery

Move preset fallback handling into the chat gateways and fail fast when no default preset is configured.

New Features:
- Handle preset fallback centrally in completion, tool-calling, and embedding gateways with gateway-specific fallback contexts.
- Expose distinct completion, tools, and embedding fallback event context types for targeted matchers.

Bug Fixes:
- Fail immediately when no default preset is configured instead of selecting an arbitrary preset.

Enhancements:
- Remove fallback and retry orchestration from the LLM workflow node so it only consumes the completion stream.

Build:
- Bump the package version from 0.13.5 to 0.13.6.

Documentation:
- Document gateway-level fallback contexts and the fail-fast default-preset behavior in English and Chinese API references and README files.

Tests:
- Add coverage for gateway fallback switching, missing fallback handlers, exhausted retries, event types, and embedding input validation.
- Update preset and coverage tests for the required default preset.