### PR TITLE
Use active model preset for memory summarization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita_core"
-version = "0.13.6"
+version = "0.13.7"
 description = "High performance, flexible, lightweight agent framework."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/amrita_core/chatmanager/chat_object.py
+++ b/src/amrita_core/chatmanager/chat_object.py
@@ -690,7 +690,11 @@ async def _limiting_memory(chat_obj: ChatObject):
         return
     assert mem_ctx.memory is not None, "Memory must be loaded before limiting"
     async with MemoryLimiter(
-        mem_ctx.memory, input_ctx.train, config=ab.config, usage=resp.usage
+        mem_ctx.memory,
+        input_ctx.train,
+        config=ab.config,
+        preset=ab.preset,
+        usage=resp.usage,
     ) as lim:
         await chat_obj.io_stream._wait_for_continue(SuspendEnum.MEMORY)
         await lim.run_enforce()

--- a/src/amrita_core/chatmanager/memory_limiter.py
+++ b/src/amrita_core/chatmanager/memory_limiter.py
@@ -19,6 +19,7 @@ from amrita_core.types import (
     CT_MAP,
     Content,
     Message,
+    ModelPreset,
     ToolResult,
     UniResponseUsage,
 )
@@ -44,6 +45,7 @@ class MemoryLimiter:
     _copied_messages: Memory  # Original message copies (for rollback on exceptions)
     _abstract_instruction = ABSTRACT_INSTRUCTION
     _usage: SessionUsageProxy | None = None  # Run-scoped ledger proxy, if any
+    _preset: ModelPreset | None = None  # Preset used for the summary call, if any
 
     def __init__(
         self,
@@ -52,6 +54,7 @@ class MemoryLimiter:
         config: AmritaConfig | None = None,
         abstract_instruction: str | None = None,
         usage: SessionUsageProxy | None = None,
+        preset: ModelPreset | None = None,
     ) -> None:
         """Initialize context processor
 
@@ -62,6 +65,8 @@ class MemoryLimiter:
             abstract_instruction: Optional custom abstract instruction
             usage: Optional run-scoped usage proxy; the summary call's
                 provider usage is recorded through it when given.
+            preset: Model preset to use for the summary call; when omitted,
+                falls back to the global default (if set).
         """
         self.memory: Memory = memory
         self.config = config or get_config()
@@ -70,6 +75,7 @@ class MemoryLimiter:
         )
         self._abstract_instruction = abstract_instruction or ABSTRACT_INSTRUCTION
         self._usage = usage
+        self._preset = preset
 
     async def __aenter__(self) -> Self:
         """Async context manager entry, initialize processing state
@@ -170,7 +176,7 @@ class MemoryLimiter:
             ]
             logger.debug("Performing context summarization...")
             response = await get_last_response(
-                call_completion(msg_list, usage=self._usage)
+                call_completion(msg_list, usage=self._usage, preset=self._preset)
             )
             if response.usage is not None:
                 # Provider-reported usage (already recorded via the proxy).


### PR DESCRIPTION
## Summary by Sourcery

Use the active model preset for memory summarization to keep limiter-generated calls consistent with the chat configuration.

Bug Fixes:
- Ensure memory summarization uses the active model preset instead of silently falling back to the global default.

Enhancements:
- Propagate the chat object's model preset and run-scoped usage context into memory limiting and summary calls.

Chores:
- Bump the package version to 0.13.7.